### PR TITLE
MUSL scheme implementation

### DIFF
--- a/include/io/logger.h
+++ b/include/io/logger.h
@@ -41,6 +41,9 @@ struct Logger {
 
   // Create a logger for MPM Explicit USL
   static const std::shared_ptr<spdlog::logger> mpm_explicit_usl_logger;
+
+  // Create a logger for MPM Explicit MUSL
+  static const std::shared_ptr<spdlog::logger> mpm_explicit_musl_logger;
 };
 
 }  // namespace mpm

--- a/include/node.h
+++ b/include/node.h
@@ -37,8 +37,8 @@ class Node : public NodeBase<Tdim> {
   //! Initialise nodal properties
   void initialise() noexcept override;
 
-  //! Initialise nodal mass and momentum (only for musl)
-  void initialise_mass_momentum() noexcept override;
+  //! Initialise nodal momentum (only for musl)
+  void initialise_momentum() noexcept override;
 
   //! Return id of the nodebase
   Index id() const override { return id_; }

--- a/include/node.h
+++ b/include/node.h
@@ -37,6 +37,9 @@ class Node : public NodeBase<Tdim> {
   //! Initialise nodal properties
   void initialise() noexcept override;
 
+  //! Initialise nodal mass and momentum (only for musl)
+  void initialise_mass_momentum() noexcept override;
+
   //! Return id of the nodebase
   Index id() const override { return id_; }
 

--- a/include/node.tcc
+++ b/include/node.tcc
@@ -36,10 +36,9 @@ void mpm::Node<Tdim, Tdof, Tnphases>::initialise() noexcept {
   material_ids_.clear();
 }
 
-//! Initialise nodal mass and momentum (only for musl)
+//! Initialise nodal momentum (only for musl)
 template <unsigned Tdim, unsigned Tdof, unsigned Tnphases>
-void mpm::Node<Tdim, Tdof, Tnphases>::initialise_mass_momentum() noexcept {
-  mass_.setZero();
+void mpm::Node<Tdim, Tdof, Tnphases>::initialise_momentum() noexcept {
   momentum_.setZero();
 }
 

--- a/include/node.tcc
+++ b/include/node.tcc
@@ -36,6 +36,13 @@ void mpm::Node<Tdim, Tdof, Tnphases>::initialise() noexcept {
   material_ids_.clear();
 }
 
+//! Initialise nodal mass and momentum (only for musl)
+template <unsigned Tdim, unsigned Tdof, unsigned Tnphases>
+void mpm::Node<Tdim, Tdof, Tnphases>::initialise_mass_momentum() noexcept {
+  mass_.setZero();
+  momentum_.setZero();
+}
+
 //! Initialise shared pointer to nodal properties pool
 template <unsigned Tdim, unsigned Tdof, unsigned Tnphases>
 void mpm::Node<Tdim, Tdof, Tnphases>::initialise_property_handle(

--- a/include/node_base.h
+++ b/include/node_base.h
@@ -61,6 +61,9 @@ class NodeBase {
   //! Initialise properties
   virtual void initialise() noexcept = 0;
 
+  //! Initialise nodal mass and momentum (only for musl)
+  virtual void initialise_mass_momentum() noexcept = 0;
+
   //! Return degrees of freedom
   virtual unsigned dof() const = 0;
 

--- a/include/node_base.h
+++ b/include/node_base.h
@@ -61,8 +61,8 @@ class NodeBase {
   //! Initialise properties
   virtual void initialise() noexcept = 0;
 
-  //! Initialise nodal mass and momentum (only for musl)
-  virtual void initialise_mass_momentum() noexcept = 0;
+  //! Initialise nodal momentum (only for musl)
+  virtual void initialise_momentum() noexcept = 0;
 
   //! Return degrees of freedom
   virtual unsigned dof() const = 0;

--- a/include/particles/particle.h
+++ b/include/particles/particle.h
@@ -234,6 +234,18 @@ class Particle : public ParticleBase<Tdim> {
   void compute_updated_position(double dt,
                                 bool velocity_update = false) noexcept override;
 
+  //! Compute updated velocity of the particle for musl
+  //! \param[in] dt Analysis time step
+  //! \param[in] velocity_update Update particle velocity from nodal vel
+  void compute_updated_velocity_musl(
+      double dt, bool velocity_update = false) noexcept override;
+
+  //! Compute updated position of the particle for musl
+  //! \param[in] dt Analysis time step
+  //! \param[in] velocity_update Update particle velocity from nodal vel
+  void compute_updated_position_musl(
+      double dt, bool velocity_update = false) noexcept override;
+
   //! Return a state variable
   //! \param[in] var State variable
   //! \param[in] phase Index to indicate phase

--- a/include/particles/particle.h
+++ b/include/particles/particle.h
@@ -140,6 +140,9 @@ class Particle : public ParticleBase<Tdim> {
   //! Map particle mass and momentum to nodes
   void map_mass_momentum_to_nodes() noexcept override;
 
+  //! Map particle momentum to nodes (only for musl)
+  void map_momentum_to_nodes() noexcept override;
+
   //! Map multimaterial properties to nodes
   void map_multimaterial_mass_momentum_to_nodes() noexcept override;
 

--- a/include/particles/particle.tcc
+++ b/include/particles/particle.tcc
@@ -531,6 +531,19 @@ void mpm::Particle<Tdim>::map_mass_momentum_to_nodes() noexcept {
   }
 }
 
+//! Map particle momentum to nodes (only for musl)
+template <unsigned Tdim>
+void mpm::Particle<Tdim>::map_momentum_to_nodes() noexcept {
+  // Check if particle mass is set
+  assert(mass_ != std::numeric_limits<double>::max());
+
+  // Map mass and momentum to nodes
+  for (unsigned i = 0; i < nodes_.size(); ++i) {
+    nodes_[i]->update_momentum(true, mpm::ParticlePhase::Solid,
+                               mass_ * shapefn_[i] * velocity_);
+  }
+}
+
 //! Map multimaterial properties to nodes
 template <unsigned Tdim>
 void mpm::Particle<Tdim>::map_multimaterial_mass_momentum_to_nodes() noexcept {

--- a/include/particles/particle_base.h
+++ b/include/particles/particle_base.h
@@ -261,6 +261,14 @@ class ParticleBase {
   virtual void compute_updated_position(
       double dt, bool velocity_update = false) noexcept = 0;
 
+  //! Compute updated velocity for musl
+  virtual void compute_updated_velocity_musl(
+      double dt, bool velocity_update = false) noexcept = 0;
+
+  //! Compute updated position for musl
+  virtual void compute_updated_position_musl(
+      double dt, bool velocity_update = false) noexcept = 0;
+
   //! Return a state variable
   virtual double state_variable(
       const std::string& var,

--- a/include/particles/particle_base.h
+++ b/include/particles/particle_base.h
@@ -150,6 +150,9 @@ class ParticleBase {
   //! Map particle mass and momentum to nodes
   virtual void map_mass_momentum_to_nodes() noexcept = 0;
 
+  //! Map particle momentum to nodes (only for musl)
+  virtual void map_momentum_to_nodes() noexcept = 0;
+
   //! Map multimaterial properties to nodes
   virtual void map_multimaterial_mass_momentum_to_nodes() noexcept = 0;
 

--- a/include/solvers/mpm_base.h
+++ b/include/solvers/mpm_base.h
@@ -24,6 +24,7 @@
 #include "mpm_scheme.h"
 #include "mpm_scheme_usf.h"
 #include "mpm_scheme_usl.h"
+#include "mpm_scheme_musl.h"
 #include "particle.h"
 #include "vector.h"
 

--- a/include/solvers/mpm_explicit.tcc
+++ b/include/solvers/mpm_explicit.tcc
@@ -7,6 +7,8 @@ mpm::MPMExplicit<Tdim>::MPMExplicit(const std::shared_ptr<IO>& io)
   //! Stress update
   if (this->stress_update_ == "usl")
     mpm_scheme_ = std::make_shared<mpm::MPMSchemeUSL<Tdim>>(mesh_, dt_);
+  else if (this->stress_update_ == "musl")
+    mpm_scheme_ = std::make_shared<mpm::MPMSchemeMUSL<Tdim>>(mesh_, dt_);
   else
     mpm_scheme_ = std::make_shared<mpm::MPMSchemeUSF<Tdim>>(mesh_, dt_);
 
@@ -148,6 +150,9 @@ bool mpm::MPMExplicit<Tdim>::solve() {
     // Particle kinematics
     mpm_scheme_->compute_particle_kinematics(velocity_update_, phase, "Cundall",
                                              damping_factor_);
+
+    // Particle positions (only for MUSL)
+    mpm_scheme_->compute_particle_updated_position(velocity_update_, phase);
 
     // Update Stress Last
     mpm_scheme_->postcompute_stress_strain(phase, pressure_smoothing_);

--- a/include/solvers/mpm_scheme/mpm_scheme.h
+++ b/include/solvers/mpm_scheme/mpm_scheme.h
@@ -66,6 +66,11 @@ class MPMScheme {
       bool velocity_update, unsigned phase, const std::string& damping_type,
       double damping_factor);
 
+  //! Recompute nodal kinematics and compute particle position (only for musl)
+  //! \param[in] phase Phase of particle
+  virtual inline void compute_particle_updated_position(
+      bool velocity_update, unsigned phase) = 0;
+
   //! Compute particle location
   //! \param[in] locate_particles Flag to enable locate particles, if set to
   //! false, unlocated particles will be removed

--- a/include/solvers/mpm_scheme/mpm_scheme_musl.h
+++ b/include/solvers/mpm_scheme/mpm_scheme_musl.h
@@ -1,5 +1,5 @@
-#ifndef MPM_MPM_SCHEME_USF_H_
-#define MPM_MPM_SCHEME_USF_H_
+#ifndef MPM_MPM_SCHEME_MUSL_H_
+#define MPM_MPM_SCHEME_MUSL_H_
 
 #ifdef USE_GRAPH_PARTITIONING
 #include "graph.h"
@@ -9,14 +9,14 @@
 
 namespace mpm {
 
-//! MPMSchemeUSF class
-//! \brief MPMSchemeUSF Derived class for USF stress update scheme
+//! MPMSchemeMUSL class
+//! \brief MPMSchemeUSL Derived class for MUSL stress update scheme
 //! \tparam Tdim Dimension
 template <unsigned Tdim>
-class MPMSchemeUSF : public MPMScheme<Tdim> {
+class MPMSchemeMUSL : public MPMScheme<Tdim> {
  public:
   //! Default constructor with mesh class
-  MPMSchemeUSF(const std::shared_ptr<mpm::Mesh<Tdim>>& mesh, double dt);
+  MPMSchemeMUSL(const std::shared_ptr<mpm::Mesh<Tdim>>& mesh, double dt);
 
   //! Precompute stress
   //! \param[in] phase Phase to smooth postssure
@@ -29,11 +29,19 @@ class MPMSchemeUSF : public MPMScheme<Tdim> {
   virtual inline void postcompute_stress_strain(
       unsigned phase, bool pressure_smoothing) override;
 
-  //! Recompute nodal kinematics and compute particle position (only for musl)
+  //! Compute acceleration velocity position
+  //! \param[in] velocity_update Velocity or acceleration update flag
   //! \param[in] phase Phase of particle
-  virtual inline void compute_particle_updated_position(
-      bool velocity_update, unsigned phase) override;
-      
+  //! \param[in] damping_type Type of damping
+  //! \param[in] damping_factor Value of critical damping
+  virtual inline void compute_particle_kinematics(
+      bool velocity_update, unsigned phase, const std::string& damping_type,
+      double damping_factor) override;
+
+  //! Compute position
+  //! \param[in] phase Phase of particle
+  virtual inline void compute_particle_updated_position(bool velocity_update, unsigned phase) override;
+
   //! Stress update scheme
   //! \retval scheme Stress update scheme
   virtual inline std::string scheme() const override;
@@ -48,9 +56,9 @@ class MPMSchemeUSF : public MPMScheme<Tdim> {
   //! Time increment
   using mpm::MPMScheme<Tdim>::dt_;
 
-};  // MPMSchemeUSF class
+};  // MPMSchemeMUSL class
 }  // namespace mpm
 
-#include "mpm_scheme_usf.tcc"
+#include "mpm_scheme_musl.tcc"
 
-#endif  // MPM_MPM_SCHEME_H_
+#endif  // MPM_MPM_SCHEME_MUSL_H_

--- a/include/solvers/mpm_scheme/mpm_scheme_musl.tcc
+++ b/include/solvers/mpm_scheme/mpm_scheme_musl.tcc
@@ -1,0 +1,100 @@
+//! Constructor
+template <unsigned Tdim>
+mpm::MPMSchemeMUSL<Tdim>::MPMSchemeMUSL(
+    const std::shared_ptr<mpm::Mesh<Tdim>>& mesh, double dt)
+    : mpm::MPMScheme<Tdim>(mesh, dt) {}
+
+//! Precompute stresses and strains
+template <unsigned Tdim>
+inline void mpm::MPMSchemeMUSL<Tdim>::precompute_stress_strain(
+    unsigned phase, bool pressure_smoothing) {}
+
+//! Postcompute stresses and strains
+template <unsigned Tdim>
+inline void mpm::MPMSchemeMUSL<Tdim>::postcompute_stress_strain(
+    unsigned phase, bool pressure_smoothing) {
+  mpm::MPMScheme<Tdim>::compute_stress_strain(phase, pressure_smoothing);
+}
+
+// Compute particle kinematics
+template <unsigned Tdim>
+inline void mpm::MPMSchemeMUSL<Tdim>::compute_particle_kinematics(
+    bool velocity_update, unsigned phase, const std::string& damping_type,
+    double damping_factor) {
+
+  // Check if damping has been specified and accordingly Iterate over
+  // active nodes to compute acceleratation and velocity
+  if (damping_type == "Cundall")
+    mesh_->iterate_over_nodes_predicate(
+        std::bind(&mpm::NodeBase<Tdim>::compute_acceleration_velocity_cundall,
+                  std::placeholders::_1, phase, dt_, damping_factor),
+        std::bind(&mpm::NodeBase<Tdim>::status, std::placeholders::_1));
+  else
+    mesh_->iterate_over_nodes_predicate(
+        std::bind(&mpm::NodeBase<Tdim>::compute_acceleration_velocity,
+                  std::placeholders::_1, phase, dt_),
+        std::bind(&mpm::NodeBase<Tdim>::status, std::placeholders::_1));
+
+  // Iterate over each particle to compute updated velocity
+  mesh_->iterate_over_particles(
+      std::bind(&mpm::ParticleBase<Tdim>::compute_updated_velocity_musl,
+                std::placeholders::_1, dt_, velocity_update));
+
+  // Apply particle velocity constraints
+  mesh_->apply_particle_velocity_constraints();
+}
+
+//! Recompute nodal kinematics and compute particle position (only for musl)
+template <unsigned Tdim>
+inline void mpm::MPMSchemeMUSL<Tdim>::compute_particle_updated_position(
+    bool velocity_update, unsigned phase) {
+
+#pragma omp parallel sections
+  {
+    // Spawn a task for initialising nodes and cells
+#pragma omp section
+    {
+      // Initialise nodes
+      mesh_->iterate_over_nodes_predicate(
+          std::bind(&mpm::NodeBase<Tdim>::initialise_mass_momentum, std::placeholders::_1),
+          std::bind(&mpm::NodeBase<Tdim>::status, std::placeholders::_1));
+    }
+  }
+
+  // Assign mass and momentum to nodes
+  mesh_->iterate_over_particles(
+      std::bind(&mpm::ParticleBase<Tdim>::map_mass_momentum_to_nodes,
+                std::placeholders::_1));
+
+#ifdef USE_MPI
+  // Run if there is more than a single MPI task
+  if (mpi_size_ > 1) {
+    // MPI all reduce nodal mass
+    mesh_->template nodal_halo_exchange<double, 1>(
+        std::bind(&mpm::NodeBase<Tdim>::mass, std::placeholders::_1, phase),
+        std::bind(&mpm::NodeBase<Tdim>::update_mass, std::placeholders::_1,
+                  false, phase, std::placeholders::_2));
+    // MPI all reduce nodal momentum
+    mesh_->template nodal_halo_exchange<Eigen::Matrix<double, Tdim, 1>, Tdim>(
+        std::bind(&mpm::NodeBase<Tdim>::momentum, std::placeholders::_1, phase),
+        std::bind(&mpm::NodeBase<Tdim>::update_momentum, std::placeholders::_1,
+                  false, phase, std::placeholders::_2));
+  }
+#endif
+
+  // Compute nodal velocity
+  mesh_->iterate_over_nodes_predicate(
+      std::bind(&mpm::NodeBase<Tdim>::compute_velocity, std::placeholders::_1),
+      std::bind(&mpm::NodeBase<Tdim>::status, std::placeholders::_1));
+
+  // Iterate over each particle to compute updated position
+  mesh_->iterate_over_particles(
+      std::bind(&mpm::ParticleBase<Tdim>::compute_updated_position_musl,
+                std::placeholders::_1, dt_, velocity_update));
+}
+
+//! Stress update scheme
+template <unsigned Tdim>
+inline std::string mpm::MPMSchemeMUSL<Tdim>::scheme() const {
+  return "MUSL";
+}

--- a/include/solvers/mpm_scheme/mpm_scheme_musl.tcc
+++ b/include/solvers/mpm_scheme/mpm_scheme_musl.tcc
@@ -51,19 +51,19 @@ inline void mpm::MPMSchemeMUSL<Tdim>::compute_particle_updated_position(
 
 #pragma omp parallel sections
   {
-    // Spawn a task for initialising nodes and cells
+    // Spawn a task for initialising nodal momentum
 #pragma omp section
     {
-      // Initialise nodes
+      // Initialise nodal momentum
       mesh_->iterate_over_nodes_predicate(
-          std::bind(&mpm::NodeBase<Tdim>::initialise_mass_momentum, std::placeholders::_1),
+          std::bind(&mpm::NodeBase<Tdim>::initialise_momentum, std::placeholders::_1),
           std::bind(&mpm::NodeBase<Tdim>::status, std::placeholders::_1));
     }
   }
 
-  // Assign mass and momentum to nodes
+  // Assign momentum to nodes
   mesh_->iterate_over_particles(
-      std::bind(&mpm::ParticleBase<Tdim>::map_mass_momentum_to_nodes,
+      std::bind(&mpm::ParticleBase<Tdim>::map_momentum_to_nodes,
                 std::placeholders::_1));
 
 #ifdef USE_MPI

--- a/include/solvers/mpm_scheme/mpm_scheme_usf.tcc
+++ b/include/solvers/mpm_scheme/mpm_scheme_usf.tcc
@@ -16,6 +16,11 @@ template <unsigned Tdim>
 inline void mpm::MPMSchemeUSF<Tdim>::postcompute_stress_strain(
     unsigned phase, bool pressure_smoothing) {}
 
+//! Recompute nodal kinematics and compute particle position (only for musl)
+template <unsigned Tdim>
+inline void mpm::MPMSchemeUSF<Tdim>::compute_particle_updated_position(
+  bool velocity_update, unsigned phase) {}
+
 //! Stress update scheme
 template <unsigned Tdim>
 inline std::string mpm::MPMSchemeUSF<Tdim>::scheme() const {

--- a/include/solvers/mpm_scheme/mpm_scheme_usl.h
+++ b/include/solvers/mpm_scheme/mpm_scheme_usl.h
@@ -29,6 +29,11 @@ class MPMSchemeUSL : public MPMScheme<Tdim> {
   virtual inline void postcompute_stress_strain(
       unsigned phase, bool pressure_smoothing) override;
 
+  //! Recompute nodal kinematics and compute particle position (only for musl)
+  //! \param[in] phase Phase of particle
+  virtual inline void compute_particle_updated_position(
+      bool velocity_update, unsigned phase) override;
+
   //! Stress update scheme
   //! \retval scheme Stress update scheme
   virtual inline std::string scheme() const override;

--- a/include/solvers/mpm_scheme/mpm_scheme_usl.tcc
+++ b/include/solvers/mpm_scheme/mpm_scheme_usl.tcc
@@ -16,6 +16,11 @@ inline void mpm::MPMSchemeUSL<Tdim>::postcompute_stress_strain(
   mpm::MPMScheme<Tdim>::compute_stress_strain(phase, pressure_smoothing);
 }
 
+//! Recompute nodal kinematics and compute particle position (only for musl)
+template <unsigned Tdim>
+inline void mpm::MPMSchemeUSL<Tdim>::compute_particle_updated_position(
+  bool velocity_update, unsigned phase) {}
+
 //! Stress update scheme
 template <unsigned Tdim>
 inline std::string mpm::MPMSchemeUSL<Tdim>::scheme() const {

--- a/src/io/logger.cc
+++ b/src/io/logger.cc
@@ -35,3 +35,7 @@ const std::shared_ptr<spdlog::logger> mpm::Logger::mpm_explicit_usf_logger =
 // Create a logger for MPM Explicit USL
 const std::shared_ptr<spdlog::logger> mpm::Logger::mpm_explicit_usl_logger =
     spdlog::stdout_color_st("MPMExplicitUSL");
+
+// Create a logger for MPM Explicit MUSL
+const std::shared_ptr<spdlog::logger> mpm::Logger::mpm_explicit_musl_logger =
+    spdlog::stdout_color_st("MPMExplicitMUSL");

--- a/tests/solvers/mpm_explicit_musl_test.cc
+++ b/tests/solvers/mpm_explicit_musl_test.cc
@@ -1,0 +1,209 @@
+#include "catch.hpp"
+
+//! Alias for JSON
+#include "json.hpp"
+using Json = nlohmann::json;
+
+#include "mpm_explicit.h"
+#include "write_mesh_particles.h"
+
+// Check MPM Explicit
+TEST_CASE("MPM 2D Explicit implementation is checked",
+          "[MPM][2D][Explicit][MUSL][1Phase]") {
+  // Dimension
+  const unsigned Dim = 2;
+
+  // Write JSON file
+  const std::string fname = "mpm-explicit-musl";
+  const std::string analysis = "MPMExplicit2D";
+  const std::string mpm_scheme = "musl";
+
+  // Write JSON Entity Sets file
+  REQUIRE(mpm_test::write_entity_set() == true);
+
+  // Write Mesh
+  REQUIRE(mpm_test::write_mesh_2d() == true);
+
+  // Write Particles
+  REQUIRE(mpm_test::write_particles_2d() == true);
+
+  // Assign argc and argv to input arguments of MPM
+  int argc = 5;
+  // clang-format off
+  char* argv[] = {(char*)"./mpm",
+                  (char*)"-f",  (char*)"./",
+                  (char*)"-i",  (char*)"mpm-explicit-musl-2d.json"};
+  // clang-format on
+
+  SECTION("Check initialisation") {
+    bool resume = false;
+    REQUIRE(mpm_test::write_json(2, resume, analysis, mpm_scheme, fname) ==
+            true);
+
+    // Create an IO object
+    auto io = std::make_unique<mpm::IO>(argc, argv);
+    // Run explicit MPM
+    auto mpm = std::make_unique<mpm::MPMExplicit<Dim>>(std::move(io));
+
+    // Initialise materials
+    REQUIRE_NOTHROW(mpm->initialise_materials());
+    // Initialise mesh
+    REQUIRE_NOTHROW(mpm->initialise_mesh());
+    // Initialise particles
+    REQUIRE_NOTHROW(mpm->initialise_particles());
+
+    // Initialise external loading
+    REQUIRE_NOTHROW(mpm->initialise_loads());
+
+    // Renitialise materials
+    REQUIRE_THROWS(mpm->initialise_materials());
+  }
+
+  SECTION("Check solver") {
+    // Create an IO object
+    auto io = std::make_unique<mpm::IO>(argc, argv);
+    // Run explicit MPM
+    auto mpm = std::make_unique<mpm::MPMExplicit<Dim>>(std::move(io));
+    // Solve
+    REQUIRE(mpm->solve() == true);
+    // Test check point restart
+    REQUIRE(mpm->checkpoint_resume() == false);
+  }
+
+  SECTION("Check resume") {
+    // Write JSON file
+    const std::string fname = "mpm-explicit-musl";
+    const std::string analysis = "MPMExplicit2D";
+    const std::string mpm_scheme = "musl";
+    bool resume = true;
+    REQUIRE(mpm_test::write_json(2, true, analysis, mpm_scheme, fname) == true);
+
+    // Create an IO object
+    auto io = std::make_unique<mpm::IO>(argc, argv);
+    // Run explicit MPM
+    auto mpm = std::make_unique<mpm::MPMExplicit<Dim>>(std::move(io));
+
+    // Initialise materials
+    REQUIRE_NOTHROW(mpm->initialise_materials());
+    // Initialise mesh
+    REQUIRE_NOTHROW(mpm->initialise_mesh());
+
+    // Test check point restart
+    REQUIRE(mpm->checkpoint_resume() == true);
+    {
+      // Solve
+      auto io = std::make_unique<mpm::IO>(argc, argv);
+      // Run explicit MPM
+      auto mpm_resume = std::make_unique<mpm::MPMExplicit<Dim>>(std::move(io));
+      REQUIRE(mpm_resume->solve() == true);
+    }
+  }
+
+  SECTION("Check pressure smoothing") {
+    // Create an IO object
+    auto io = std::make_unique<mpm::IO>(argc, argv);
+    // Run explicit MPM
+    auto mpm = std::make_unique<mpm::MPMExplicit<Dim>>(std::move(io));
+    // Pressure smoothing
+    REQUIRE_NOTHROW(mpm->pressure_smoothing(0));
+  }
+}
+
+// Check MPM Explicit
+TEST_CASE("MPM 3D Explicit implementation is checked",
+          "[MPM][3D][Explicit][MUSL][1Phase]") {
+  // Dimension
+  const unsigned Dim = 3;
+
+  // Write JSON file
+  const std::string fname = "mpm-explicit-musl";
+  const std::string analysis = "MPMExplicit3D";
+  const std::string mpm_scheme = "musl";
+
+  // Write JSON Entity Sets file
+  REQUIRE(mpm_test::write_entity_set() == true);
+
+  // Write Mesh
+  REQUIRE(mpm_test::write_mesh_3d() == true);
+
+  // Write Particles
+  REQUIRE(mpm_test::write_particles_3d() == true);
+
+  // Assign argc and argv to input arguments of MPM
+  int argc = 5;
+  // clang-format off
+  char* argv[] = {(char*)"./mpm",
+                  (char*)"-f",  (char*)"./",
+                  (char*)"-i",  (char*)"mpm-explicit-musl-3d.json"};
+  // clang-format on
+
+  SECTION("Check initialisation") {
+    const bool resume = false;
+    REQUIRE(mpm_test::write_json(3, resume, analysis, mpm_scheme, fname) ==
+            true);
+
+    // Create an IO object
+    auto io = std::make_unique<mpm::IO>(argc, argv);
+    // Run explicit MPM
+    auto mpm = std::make_unique<mpm::MPMExplicit<Dim>>(std::move(io));
+
+    // Initialise materials
+    REQUIRE_NOTHROW(mpm->initialise_materials());
+    // Initialise mesh
+    REQUIRE_NOTHROW(mpm->initialise_mesh());
+    // Initialise particles
+    REQUIRE_NOTHROW(mpm->initialise_particles());
+
+    // Renitialise materials
+    REQUIRE_THROWS(mpm->initialise_materials());
+  }
+
+  SECTION("Check solver") {
+    // Create an IO object
+    auto io = std::make_unique<mpm::IO>(argc, argv);
+    // Run explicit MPM
+    auto mpm = std::make_unique<mpm::MPMExplicit<Dim>>(std::move(io));
+    // Solve
+    REQUIRE(mpm->solve() == true);
+    // Test check point restart
+    REQUIRE(mpm->checkpoint_resume() == false);
+  }
+
+  SECTION("Check resume") {
+    // Write JSON file
+    const std::string fname = "mpm-explicit-musl";
+    const std::string analysis = "MPMExplicit3D";
+    const std::string mpm_scheme = "musl";
+    bool resume = true;
+    REQUIRE(mpm_test::write_json(3, resume, analysis, mpm_scheme, fname) ==
+            true);
+
+    // Create an IO object
+    auto io = std::make_unique<mpm::IO>(argc, argv);
+    // Run explicit MPM
+    auto mpm = std::make_unique<mpm::MPMExplicit<Dim>>(std::move(io));
+
+    // Initialise materials
+    REQUIRE_NOTHROW(mpm->initialise_materials());
+    // Initialise mesh
+    REQUIRE_NOTHROW(mpm->initialise_mesh());
+    // Test check point restart
+    REQUIRE(mpm->checkpoint_resume() == true);
+    {
+      // Solve
+      auto io = std::make_unique<mpm::IO>(argc, argv);
+      // Run explicit MPM
+      auto mpm_resume = std::make_unique<mpm::MPMExplicit<Dim>>(std::move(io));
+      REQUIRE(mpm_resume->solve() == true);
+    }
+  }
+
+  SECTION("Check pressure smoothing") {
+    // Create an IO object
+    auto io = std::make_unique<mpm::IO>(argc, argv);
+    // Run explicit MPM
+    auto mpm = std::make_unique<mpm::MPMExplicit<Dim>>(std::move(io));
+    // Pressure smoothing
+    REQUIRE_NOTHROW(mpm->pressure_smoothing(0));
+  }
+}

--- a/tests/solvers/mpm_explicit_musl_unitcell_test.cc
+++ b/tests/solvers/mpm_explicit_musl_unitcell_test.cc
@@ -1,0 +1,119 @@
+#include "catch.hpp"
+
+//! Alias for JSON
+#include "json.hpp"
+using Json = nlohmann::json;
+
+#include "mpm_explicit.h"
+#include "write_mesh_particles_unitcell.h"
+
+// Check MPM Explicit MUSL
+TEST_CASE("MPM 2D Explicit MUSL implementation is checked in unitcells",
+          "[MPM][2D][MUSL][Explicit][1Phase][unitcell]") {
+  // Dimension
+  const unsigned Dim = 2;
+
+  // Write JSON file
+  const std::string fname = "mpm-explicit-musl";
+  const std::string analysis = "MPMExplicit2D";
+  const std::string mpm_scheme = "musl";
+  REQUIRE(mpm_test::write_json_unitcell(2, analysis, mpm_scheme, fname) ==
+          true);
+
+  // Write Mesh
+  REQUIRE(mpm_test::write_mesh_2d_unitcell() == true);
+
+  // Write Particles
+  REQUIRE(mpm_test::write_particles_2d_unitcell() == true);
+
+  // Assign argc and argv to input arguments of MPM
+  int argc = 5;
+  // clang-format off
+  char* argv[] = {(char*)"./mpm",
+                  (char*)"-f",  (char*)"./",
+                  (char*)"-i",  (char*)"mpm-explicit-musl-2d-unitcell.json"};
+  // clang-format on
+
+  SECTION("Check initialisation") {
+    // Create an IO object
+    auto io = std::make_unique<mpm::IO>(argc, argv);
+    // Run explicit MPM
+    auto mpm = std::make_unique<mpm::MPMExplicit<Dim>>(std::move(io));
+
+    // Initialise materials
+    REQUIRE_NOTHROW(mpm->initialise_materials());
+
+    // Initialise mesh and particles
+    REQUIRE_NOTHROW(mpm->initialise_mesh());
+    REQUIRE_NOTHROW(mpm->initialise_particles());
+
+    // Initialise external loading
+    REQUIRE_NOTHROW(mpm->initialise_loads());
+
+    // Renitialise materials
+    REQUIRE_THROWS(mpm->initialise_materials());
+  }
+
+  SECTION("Check solver") {
+    // Create an IO object
+    auto io = std::make_unique<mpm::IO>(argc, argv);
+    // Run explicit MPM
+    auto mpm = std::make_unique<mpm::MPMExplicit<Dim>>(std::move(io));
+    // Solve
+    REQUIRE(mpm->solve() == true);
+  }
+}
+
+// Check MPM Explicit
+TEST_CASE("MPM 3D Explicit MUSL implementation is checked in unitcells",
+          "[MPM][3D][Explicit][MUSL][1Phase][unitcell]") {
+  // Dimension
+  const unsigned Dim = 3;
+
+  // Write JSON file
+  const std::string fname = "mpm-explicit-musl";
+  const std::string analysis = "MPMExplicit3D";
+  const std::string mpm_scheme = "musl";
+  REQUIRE(mpm_test::write_json_unitcell(3, analysis, mpm_scheme, fname) ==
+          true);
+
+  // Write Mesh
+  REQUIRE(mpm_test::write_mesh_3d_unitcell() == true);
+
+  // Write Particles
+  REQUIRE(mpm_test::write_particles_3d_unitcell() == true);
+
+  // Assign argc and argv to input arguments of MPM
+  int argc = 5;
+  // clang-format off
+  char* argv[] = {(char*)"./mpm",
+                  (char*)"-f",  (char*)"./",
+                  (char*)"-i",  (char*)"mpm-explicit-musl-3d-unitcell.json"};
+  // clang-format on
+
+  SECTION("Check initialisation") {
+    // Create an IO object
+    auto io = std::make_unique<mpm::IO>(argc, argv);
+    // Run explicit MPM
+    auto mpm = std::make_unique<mpm::MPMExplicit<Dim>>(std::move(io));
+
+    // Initialise materials
+    REQUIRE_NOTHROW(mpm->initialise_materials());
+
+    // Initialise mesh and particles
+    REQUIRE_NOTHROW(mpm->initialise_mesh());
+    REQUIRE_NOTHROW(mpm->initialise_particles());
+
+    // Renitialise materials
+    REQUIRE_THROWS(mpm->initialise_materials());
+  }
+
+  SECTION("Check solver") {
+    // Create an IO object
+    auto io = std::make_unique<mpm::IO>(argc, argv);
+    // Run explicit MPM
+    auto mpm = std::make_unique<mpm::MPMExplicit<Dim>>(std::move(io));
+    // Solve
+    REQUIRE(mpm->solve() == true);
+  }
+}


### PR DESCRIPTION
**Describe the PR**
Modified Update Stress Last (MUSL) scheme is implemented.

**Related Issues/PRs**
This PR aims to implement MUSL scheme as a stress update scheme.
The implemented procedure is as follows.
1. Update nodal velocities using unbalanced force.
2. Interpolate particle velocities from the updated nodal velocities.
3. Initialize nodal momentum.
4. Remap the particle momentum to the nodes.
5. Recalculate the nodal velocities and update the particle positions.
6. Update particle strain and stress using the recalculated nodal velocities.

**Additional context**
`input.json` is expected to look like the following.
```
  "analysis": {
    ...
    "mpm_scheme": "musl",
    ...
  },
```
The above implementation is based on the following book.
Fern, Rohe, Soga, Alonso (eds.): The material point method for geotechnical engineering: a practical guide, 69-71 pp., 2019.