### PR TITLE
[Feature] Matrix noaliasing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,7 @@ jobs:
   benchmarks:
     docker:
       - image: quay.io/cbgeo/mpm
+    resource_class: large
     steps:
       - checkout
       # GCC

--- a/include/cells/cell.tcc
+++ b/include/cells/cell.tcc
@@ -243,7 +243,7 @@ void mpm::Cell<Tdim>::compute_centroid() {
   // Calculate the centroid of the cell
   centroid_.setZero();
   for (unsigned i = 0; i < indices.size(); ++i)
-    centroid_ += nodes_[indices(i)]->coordinates();
+    centroid_.noalias() += nodes_[indices(i)]->coordinates();
 
   centroid_ /= indices.size();
 }
@@ -506,7 +506,7 @@ inline Eigen::Matrix<double, 3, 1> mpm::Cell<3>::local_coordinates_point(
       Eigen::Matrix<double, 3, 1> centre;
       centre.setZero();
       for (unsigned i = 0; i < indices.size(); ++i)
-        centre += nodal_coordinates_.row(i);
+        centre.noalias() += nodal_coordinates_.row(i);
       centre /= indices.size();
 
       xi(0) = 2. * (point(0) - centre(0)) / xlength;

--- a/include/cells/cell_implicit.tcc
+++ b/include/cells/cell_implicit.tcc
@@ -23,7 +23,7 @@ void mpm::Cell<Tdim>::compute_local_material_stiffness_matrix(
     double pvolume, double multiplier) noexcept {
 
   std::lock_guard<std::mutex> guard(cell_mutex_);
-  stiffness_matrix_ +=
+  stiffness_matrix_.noalias() +=
       bmatrix.transpose() * dmatrix * bmatrix * multiplier * pvolume;
 }
 

--- a/include/cells/cell_multiphase.tcc
+++ b/include/cells/cell_multiphase.tcc
@@ -121,7 +121,7 @@ void mpm::Cell<Tdim>::compute_local_laplacian(
     double multiplier) noexcept {
 
   std::lock_guard<std::mutex> guard(cell_mutex_);
-  laplacian_matrix_ +=
+  laplacian_matrix_.noalias() +=
       grad_shapefn * grad_shapefn.transpose() * multiplier * pvolume;
 }
 
@@ -134,7 +134,7 @@ void mpm::Cell<Tdim>::compute_local_poisson_right(
 
   std::lock_guard<std::mutex> guard(cell_mutex_);
   for (unsigned i = 0; i < Tdim; i++) {
-    poisson_right_matrix_.block(0, i * nnodes_, nnodes_, nnodes_) +=
+    poisson_right_matrix_.block(0, i * nnodes_, nnodes_, nnodes_).noalias() +=
         shapefn * grad_shapefn.col(i).transpose() * multiplier * pvolume;
   }
 }
@@ -152,8 +152,9 @@ void mpm::Cell<Tdim>::compute_local_poisson_right_twophase(
 
   std::lock_guard<std::mutex> guard(cell_mutex_);
   for (unsigned i = 0; i < Tdim; i++) {
-    poisson_right_matrix_twophase_[phase].block(0, i * nnodes_, nnodes_,
-                                                nnodes_) +=
+    poisson_right_matrix_twophase_[phase]
+        .block(0, i * nnodes_, nnodes_, nnodes_)
+        .noalias() +=
         shapefn * grad_shapefn.col(i).transpose() * multiplier * pvolume;
   }
 }
@@ -167,7 +168,7 @@ void mpm::Cell<Tdim>::compute_local_correction_matrix(
 
   std::lock_guard<std::mutex> guard(cell_mutex_);
   for (unsigned i = 0; i < Tdim; i++) {
-    correction_matrix_.block(0, i * nnodes_, nnodes_, nnodes_) +=
+    correction_matrix_.block(0, i * nnodes_, nnodes_, nnodes_).noalias() +=
         shapefn * grad_shapefn.col(i).transpose() * pvolume;
   }
 }
@@ -185,8 +186,9 @@ void mpm::Cell<Tdim>::compute_local_correction_matrix_twophase(
 
   std::lock_guard<std::mutex> guard(cell_mutex_);
   for (unsigned i = 0; i < Tdim; i++) {
-    correction_matrix_twophase_[phase].block(0, i * nnodes_, nnodes_,
-                                             nnodes_) +=
+    correction_matrix_twophase_[phase]
+        .block(0, i * nnodes_, nnodes_, nnodes_)
+        .noalias() +=
         shapefn * grad_shapefn.col(i).transpose() * multiplier * pvolume;
   }
 }

--- a/include/elements/2d/quadrilateral_bspline_element.tcc
+++ b/include/elements/2d/quadrilateral_bspline_element.tcc
@@ -39,7 +39,8 @@ inline Eigen::VectorXd
     auto local_shapefn =
         this->shapefn_local(xi, particle_size, deformation_gradient);
     for (unsigned i = 0; i < local_shapefn.size(); ++i)
-      pcoord += local_shapefn(i) * nodal_coordinates_.row(i).transpose();
+      pcoord.noalias() +=
+          local_shapefn(i) * nodal_coordinates_.row(i).transpose();
 
     //! Compute shape function following a multiplicative rule
     for (unsigned n = 0; n < this->nconnectivity_; ++n) {
@@ -92,7 +93,8 @@ inline Eigen::MatrixXd
     auto local_shapefn =
         this->shapefn_local(xi, particle_size, deformation_gradient);
     for (unsigned i = 0; i < local_shapefn.size(); ++i)
-      pcoord += local_shapefn(i) * nodal_coordinates_.row(i).transpose();
+      pcoord.noalias() +=
+          local_shapefn(i) * nodal_coordinates_.row(i).transpose();
 
     //! Compute the shape function gradient following a multiplicative rule
     for (unsigned n = 0; n < this->nconnectivity_; ++n)

--- a/include/elements/2d/quadrilateral_element.tcc
+++ b/include/elements/2d/quadrilateral_element.tcc
@@ -371,7 +371,7 @@ inline Eigen::MatrixXd
     const Eigen::Matrix<double, Tnfunctions, 1> shape_fn =
         this->shapefn(xi, Eigen::Matrix<double, Tdim, 1>::Zero(),
                       Eigen::Matrix<double, Tdim, 1>::Zero());
-    ni_nj_matrix += (shape_fn * shape_fn.transpose());
+    ni_nj_matrix.noalias() += (shape_fn * shape_fn.transpose());
   }
   return ni_nj_matrix;
 }
@@ -410,7 +410,7 @@ inline Eigen::MatrixXd
     // dN/dx = [J]^-1 * dN/dxi
     const Eigen::MatrixXd grad_shapefn = grad_sf * jacobian.inverse();
 
-    laplace_matrix += (grad_shapefn * grad_shapefn.transpose());
+    laplace_matrix.noalias() += (grad_shapefn * grad_shapefn.transpose());
   }
   return laplace_matrix;
 }

--- a/include/elements/2d/triangle_element.tcc
+++ b/include/elements/2d/triangle_element.tcc
@@ -265,7 +265,7 @@ inline Eigen::MatrixXd mpm::TriangleElement<Tdim, Tnfunctions>::ni_nj_matrix(
     const Eigen::Matrix<double, Tnfunctions, 1> shape_fn =
         this->shapefn(xi, Eigen::Matrix<double, Tdim, 1>::Zero(),
                       Eigen::Matrix<double, Tdim, 1>::Zero());
-    ni_nj_matrix += (shape_fn * shape_fn.transpose());
+    ni_nj_matrix.noalias() += (shape_fn * shape_fn.transpose());
   }
   return ni_nj_matrix;
 }
@@ -302,7 +302,7 @@ inline Eigen::MatrixXd mpm::TriangleElement<Tdim, Tnfunctions>::laplace_matrix(
     // dN/dx = [J]^-1 * dN/dxi
     const Eigen::MatrixXd grad_shapefn = grad_sf * jacobian.inverse();
 
-    laplace_matrix += (grad_shapefn * grad_shapefn.transpose());
+    laplace_matrix.noalias() += (grad_shapefn * grad_shapefn.transpose());
   }
   return laplace_matrix;
 }

--- a/include/elements/3d/hexahedron_bspline_element.tcc
+++ b/include/elements/3d/hexahedron_bspline_element.tcc
@@ -39,7 +39,8 @@ inline Eigen::VectorXd
     auto local_shapefn =
         this->shapefn_local(xi, particle_size, deformation_gradient);
     for (unsigned i = 0; i < local_shapefn.size(); ++i)
-      pcoord += local_shapefn(i) * nodal_coordinates_.row(i).transpose();
+      pcoord.noalias() +=
+          local_shapefn(i) * nodal_coordinates_.row(i).transpose();
 
     //! Compute shape function following a multiplicative rule
     for (unsigned n = 0; n < this->nconnectivity_; ++n) {
@@ -92,7 +93,8 @@ inline Eigen::MatrixXd
     auto local_shapefn =
         this->shapefn_local(xi, particle_size, deformation_gradient);
     for (unsigned i = 0; i < local_shapefn.size(); ++i)
-      pcoord += local_shapefn(i) * nodal_coordinates_.row(i).transpose();
+      pcoord.noalias() +=
+          local_shapefn(i) * nodal_coordinates_.row(i).transpose();
 
     //! Compute the shape function gradient following a multiplicative rule
     for (unsigned n = 0; n < this->nconnectivity_; ++n)

--- a/include/elements/3d/hexahedron_element.tcc
+++ b/include/elements/3d/hexahedron_element.tcc
@@ -381,7 +381,7 @@ inline Eigen::MatrixXd mpm::HexahedronElement<Tdim, Tnfunctions>::ni_nj_matrix(
     const Eigen::Matrix<double, Tnfunctions, 1> shape_fn =
         this->shapefn(xi, Eigen::Matrix<double, 3, 1>::Zero(),
                       Eigen::Matrix<double, 3, 1>::Zero());
-    ni_nj_matrix += (shape_fn * shape_fn.transpose());
+    ni_nj_matrix.noalias() += (shape_fn * shape_fn.transpose());
   }
   return ni_nj_matrix;
 }
@@ -420,7 +420,7 @@ inline Eigen::MatrixXd
     // dN/dx = [J]^-1 * dN/dxi
     const Eigen::MatrixXd grad_shapefn = grad_sf * jacobian.inverse();
 
-    laplace_matrix += (grad_shapefn * grad_shapefn.transpose());
+    laplace_matrix.noalias() += (grad_shapefn * grad_shapefn.transpose());
   }
   return laplace_matrix;
 }

--- a/include/linear_solvers/assemblers/assembler_eigen_implicit.tcc
+++ b/include/linear_solvers/assemblers/assembler_eigen_implicit.tcc
@@ -142,7 +142,8 @@ template <unsigned Tdim>
 void mpm::AssemblerEigenImplicit<Tdim>::apply_displacement_constraints() {
   try {
     // Modify residual_force_rhs_vector_
-    residual_force_rhs_vector_ -= stiffness_matrix_ * displacement_constraints_;
+    residual_force_rhs_vector_ +=
+        -stiffness_matrix_ * displacement_constraints_;
 
     // Apply displacement constraints
     for (Eigen::SparseVector<double>::InnerIterator it(

--- a/include/linear_solvers/assemblers/assembler_eigen_semi_implicit_navierstokes.tcc
+++ b/include/linear_solvers/assemblers/assembler_eigen_semi_implicit_navierstokes.tcc
@@ -187,7 +187,7 @@ void mpm::AssemblerEigenSemiImplicitNavierStokes<
     Tdim>::apply_pressure_constraints() {
   try {
     // Modify poisson_rhs_vector_
-    poisson_rhs_vector_ -= laplacian_matrix_ * pressure_constraints_;
+    poisson_rhs_vector_ += -laplacian_matrix_ * pressure_constraints_;
 
     // Apply free surface
     if (!free_surface_.empty()) {

--- a/include/linear_solvers/assemblers/assembler_eigen_semi_implicit_twophase.tcc
+++ b/include/linear_solvers/assemblers/assembler_eigen_semi_implicit_twophase.tcc
@@ -370,8 +370,8 @@ bool mpm::AssemblerEigenSemiImplicitTwoPhase<
   try {
     // Modify the force vector(b = b - A * bc)
     for (unsigned dir = 0; dir < Tdim; dir++) {
-      predictor_rhs_vector_.col(dir) -=
-          predictor_lhs_matrix_.at(dir) * velocity_constraints_.col(dir);
+      predictor_rhs_vector_.col(dir) +=
+          -predictor_lhs_matrix_.at(dir) * velocity_constraints_.col(dir);
 
       // Iterate over velocity constraints (non-zero elements)
       for (unsigned j = 0; j < velocity_constraints_.outerSize(); ++j) {

--- a/include/linear_solvers/linear_solvers/krylov_petsc.h
+++ b/include/linear_solvers/linear_solvers/krylov_petsc.h
@@ -6,7 +6,6 @@
 #include "factory.h"
 #include "mpi.h"
 #include "solver_base.h"
-#include <iostream>
 
 #ifdef USE_PETSC
 #include <petscksp.h>

--- a/include/materials/mohr_coulomb.tcc
+++ b/include/materials/mohr_coulomb.tcc
@@ -417,12 +417,12 @@ Eigen::Matrix<double, 6, 1> mpm::MohrCoulomb<Tdim>::compute_stress(
   // Correction stress based on stress
   if (fabs(yield) < Tolerance) {
     // Compute updated stress
-    updated_stress -= (lambda * de * dp_dsigma);
+    updated_stress += -(lambda * de * dp_dsigma);
     // Compute incremental of plastic deviatoric strain
     dpdstrain = lambda * dp_dq;
   } else {
     // Compute updated stress
-    updated_stress -= (lambda_trial * de * dp_dsigma_trial);
+    updated_stress += -(lambda_trial * de * dp_dsigma_trial);
     // Compute incremental of plastic deviatoric strain
     dpdstrain = lambda_trial * dp_dq_trial;
   }
@@ -456,7 +456,7 @@ Eigen::Matrix<double, 6, 1> mpm::MohrCoulomb<Tdim>::compute_stress(
         ((df_dsigma_trial.transpose() * de).dot(dp_dsigma_trial.transpose()) +
          softening_trial);
     // Correct stress back to the yield surface
-    updated_stress -= (lambda_trial * de * dp_dsigma_trial);
+    updated_stress += -(lambda_trial * de * dp_dsigma_trial);
     // Update incremental of plastic deviatoric strain
     dpdstrain += lambda_trial * dp_dq_trial;
   }

--- a/include/mesh/mesh_multiphase.tcc
+++ b/include/mesh/mesh_multiphase.tcc
@@ -140,7 +140,7 @@ bool mpm::Mesh<Tdim>::compute_free_surface_by_geometry(
                                                    "gaussian");
 
       // Inverse of renormalization matrix B
-      renormalization_matrix_inv +=
+      renormalization_matrix_inv.noalias() +=
           (particle->mass() / particle->mass_density()) * kernel_gradient *
           rel_coord.transpose();
     }
@@ -178,7 +178,7 @@ bool mpm::Mesh<Tdim>::compute_free_surface_by_geometry(
                                                      -rel_coord, "gaussian");
 
         // Sum of kernel by volume
-        temporary_vec +=
+        temporary_vec.noalias() +=
             (particle->mass() / particle->mass_density()) * kernel_gradient;
       }
       normal = -renormalization_matrix_inv.inverse() * temporary_vec;

--- a/include/nodes/node.tcc
+++ b/include/nodes/node.tcc
@@ -282,7 +282,7 @@ bool mpm::Node<Tdim, Tdof, Tnphases>::compute_acceleration_velocity(
     this->apply_friction_constraints(dt);
 
     // Velocity += acceleration * dt
-    this->velocity_.col(phase) += this->acceleration_.col(phase) * dt;
+    this->velocity_.col(phase).noalias() += this->acceleration_.col(phase) * dt;
     // Apply velocity constraints, which also sets acceleration to 0,
     // when velocity is set.
     this->apply_velocity_constraints();
@@ -318,7 +318,7 @@ bool mpm::Node<Tdim, Tdof, Tnphases>::compute_acceleration_velocity_cundall(
     this->apply_friction_constraints(dt);
 
     // Velocity += acceleration * dt
-    this->velocity_.col(phase) += this->acceleration_.col(phase) * dt;
+    this->velocity_.col(phase).noalias() += this->acceleration_.col(phase) * dt;
     // Apply velocity constraints, which also sets acceleration to 0,
     // when velocity is set.
     this->apply_velocity_constraints();
@@ -632,7 +632,7 @@ void mpm::Node<Tdim, Tdof,
         property_handle_->property("masses", prop_id_, *mitr);
 
     // displacement of the center of mass
-    contact_displacement_ += material_displacement / mass_(0, 0);
+    contact_displacement_.noalias() += material_displacement / mass_(0, 0);
     // assign nodal-multimaterial displacement by dividing it by this
     // material's mass
     property_handle_->assign_property(

--- a/include/nodes/node_multiphase.tcc
+++ b/include/nodes/node_multiphase.tcc
@@ -69,7 +69,7 @@ bool mpm::Node<Tdim, Tdof, Tnphases>::
     this->apply_friction_constraints(dt);
 
     // Velocity += acceleration * dt
-    this->velocity_ += this->acceleration_ * dt;
+    this->velocity_.noalias() += this->acceleration_ * dt;
 
     // Apply velocity constraints, which also sets acceleration to 0,
     // when velocity is set.
@@ -134,7 +134,7 @@ bool mpm::Node<Tdim, Tdof, Tnphases>::
     this->apply_friction_constraints(dt);
 
     // Velocity += acceleration * dt
-    this->velocity_ += this->acceleration_ * dt;
+    this->velocity_.noalias() += this->acceleration_ * dt;
 
     // Apply velocity constraints, which also sets acceleration to 0,
     // when velocity is set.
@@ -171,7 +171,7 @@ bool mpm::Node<Tdim, Tdof, Tnphases>::
     this->acceleration_.col(phase) += acceleration_corrected;
 
     // Update velocity
-    velocity_.col(phase) += acceleration_corrected * dt;
+    velocity_.col(phase).noalias() += acceleration_corrected * dt;
 
     // Apply friction constraints
     this->apply_friction_constraints(dt);
@@ -217,7 +217,7 @@ bool mpm::Node<Tdim, Tdof, Tnphases>::
     this->acceleration_.col(phase) = acceleration_corrected;
 
     // Update velocity
-    velocity_.col(phase) += acceleration_corrected * dt;
+    velocity_.col(phase).noalias() += acceleration_corrected * dt;
 
     // Apply friction constraints
     this->apply_friction_constraints(dt);
@@ -262,7 +262,8 @@ void mpm::Node<Tdim, Tdof, Tnphases>::update_intermediate_acceleration_velocity(
   acceleration_.col(phase) = acceleration_inter.row(active_id_).transpose();
 
   // Update nodal intermediate velocity
-  velocity_.col(phase) += dt * acceleration_inter.row(active_id_).transpose();
+  velocity_.col(phase).noalias() +=
+      dt * acceleration_inter.row(active_id_).transpose();
 }
 
 //! Update correction force

--- a/include/particles/particle.tcc
+++ b/include/particles/particle.tcc
@@ -690,7 +690,7 @@ void mpm::Particle<Tdim>::compute_strain(double dt) noexcept {
   // Update dstrain
   dstrain_ = strain_rate_ * dt;
   // Update strain
-  strain_ += dstrain_;
+  strain_.noalias() += dstrain_;
 
   // Compute at centroid
   // Strain rate for reduced integration
@@ -826,7 +826,7 @@ void mpm::Particle<Tdim>::compute_updated_position(
       Eigen::Matrix<double, Tdim, 1>::Zero();
 
   for (unsigned i = 0; i < nodes_.size(); ++i)
-    nodal_velocity +=
+    nodal_velocity.noalias() +=
         shapefn_[i] * nodes_[i]->velocity(mpm::ParticlePhase::Solid);
 
   // Acceleration update
@@ -835,20 +835,20 @@ void mpm::Particle<Tdim>::compute_updated_position(
     Eigen::Matrix<double, Tdim, 1> nodal_acceleration =
         Eigen::Matrix<double, Tdim, 1>::Zero();
     for (unsigned i = 0; i < nodes_.size(); ++i)
-      nodal_acceleration +=
+      nodal_acceleration.noalias() +=
           shapefn_[i] * nodes_[i]->acceleration(mpm::ParticlePhase::Solid);
 
     // Update particle velocity from interpolated nodal acceleration
-    this->velocity_ += nodal_acceleration * dt;
+    this->velocity_.noalias() += nodal_acceleration * dt;
   }
   // Update particle velocity using interpolated nodal velocity
   else
     this->velocity_ = nodal_velocity;
 
   // New position  current position + velocity * dt
-  this->coordinates_ += nodal_velocity * dt;
+  this->coordinates_.noalias() += nodal_velocity * dt;
   // Update displacement (displacement is initialized from zero)
-  this->displacement_ += nodal_velocity * dt;
+  this->displacement_.noalias() += nodal_velocity * dt;
 }
 
 //! Map particle pressure to nodes

--- a/include/particles/particle_fluid.tcc
+++ b/include/particles/particle_fluid.tcc
@@ -16,7 +16,7 @@ void mpm::FluidParticle<Tdim>::compute_stress() noexcept {
   mpm::Particle<Tdim>::compute_stress();
 
   // Calculate fluid turbulent stress
-  this->stress_ += this->compute_turbulent_stress();
+  this->stress_.noalias() += this->compute_turbulent_stress();
 }
 
 // Compute turbulent stress

--- a/include/particles/particle_twophase.tcc
+++ b/include/particles/particle_twophase.tcc
@@ -658,18 +658,19 @@ void mpm::TwoPhaseParticle<Tdim>::compute_updated_liquid_velocity(
     acceleration.setZero();
 
     for (unsigned i = 0; i < nodes_.size(); ++i)
-      acceleration +=
+      acceleration.noalias() +=
           shapefn_(i) * nodes_[i]->acceleration(mpm::ParticlePhase::Liquid);
 
     // Update particle velocity from interpolated nodal acceleration
-    this->liquid_velocity_ += acceleration * dt;
+    this->liquid_velocity_.noalias() += acceleration * dt;
   } else {
     // Get interpolated nodal velocity
     Eigen::Matrix<double, Tdim, 1> velocity;
     velocity.setZero();
 
     for (unsigned i = 0; i < nodes_.size(); ++i)
-      velocity += shapefn_(i) * nodes_[i]->velocity(mpm::ParticlePhase::Liquid);
+      velocity.noalias() +=
+          shapefn_(i) * nodes_[i]->velocity(mpm::ParticlePhase::Liquid);
 
     // Update particle velocity to interpolated nodal velocity
     this->liquid_velocity_ = velocity;

--- a/tests/particles/particle_test.cc
+++ b/tests/particles/particle_test.cc
@@ -1078,7 +1078,7 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
                       0., 0.1875 * 1.414213562 * 7.68;
     // clang-format on
     // Add previous external body force
-    traction_force += body_force;
+    traction_force.noalias() += body_force;
 
     // Check nodal traction force
     for (unsigned i = 0; i < traction_force.rows(); ++i)
@@ -2471,7 +2471,7 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
                       0., 0., 0.140625 * 1.587401052 * 7.68;
     // clang-format on
     // Add previous external body force
-    traction_force += body_force;
+    traction_force.noalias() += body_force;
 
     // Check nodal traction force
     for (unsigned i = 0; i < traction_force.rows(); ++i)

--- a/tests/particles/particle_twophase_test.cc
+++ b/tests/particles/particle_twophase_test.cc
@@ -1100,7 +1100,7 @@ TEST_CASE("TwoPhase Particle is checked for 2D case",
                       0., 0.1875 * 1.414213562 * 7.68;
     // clang-format on
     // Add previous external body force
-    traction_force += body_force;
+    traction_force.noalias() += body_force;
 
     // Check nodal traction force
     for (unsigned i = 0; i < traction_force.rows(); ++i)
@@ -2557,7 +2557,7 @@ TEST_CASE("TwoPhase Particle is checked for 3D case",
                       0., 0., 0.140625 * 1.587401052 * 7.68;
     // clang-format on
     // Add previous external body force
-    traction_force += body_force;
+    traction_force.noalias() += body_force;
 
     // Check nodal traction force
     for (unsigned i = 0; i < traction_force.rows(); ++i)


### PR DESCRIPTION
**Describe the PR**
While checking the performance for PR #27, I came to know that the matrix-matrix multiplication of `BDB^T` in computing stiffness matrix is quite a bottleneck of our implicit formulation. One suggestion is to do matrix no aliasing, which basically improves the memory allocation. This improves only a bit in parallel, but it seems it can help to fasten the code in a single thread.

In my 2D beam test with LME, before it takes 82s to run, and after this modification, it goes down to 55s. It's quite significant, but maybe that's just because the LME itself is not optimized yet.

I decided to do a global modification of the code. Could you please help me to check this PR for implicit and explicit solvers compared to master? @RyotaHashimoto @jgiven100. I will check the two-phase and fluid solvers.

**Related Issues/PRs**
PR #27

**Additional context**
https://eigen.tuxfamily.org/dox/TopicWritingEfficientProductExpression.html
