### PR TITLE
[Bugfix] Reduction of dmatrix for 2D

### DIFF
--- a/include/particles/particle_implicit.tcc
+++ b/include/particles/particle_implicit.tcc
@@ -143,13 +143,13 @@ inline Eigen::MatrixXd mpm::Particle<2>::reduce_dmatrix(
   dmatrix3x3.resize(3, 3);
   dmatrix3x3(0, 0) = dmatrix(0, 0);
   dmatrix3x3(0, 1) = dmatrix(0, 1);
-  dmatrix3x3(0, 2) = dmatrix(0, 4);
+  dmatrix3x3(0, 2) = dmatrix(0, 3);
   dmatrix3x3(1, 0) = dmatrix(1, 0);
   dmatrix3x3(1, 1) = dmatrix(1, 1);
-  dmatrix3x3(1, 2) = dmatrix(1, 4);
-  dmatrix3x3(2, 0) = dmatrix(4, 0);
-  dmatrix3x3(2, 1) = dmatrix(4, 1);
-  dmatrix3x3(2, 2) = dmatrix(4, 4);
+  dmatrix3x3(1, 2) = dmatrix(1, 3);
+  dmatrix3x3(2, 0) = dmatrix(3, 0);
+  dmatrix3x3(2, 1) = dmatrix(3, 1);
+  dmatrix3x3(2, 2) = dmatrix(3, 3);
 
   return dmatrix3x3;
 }


### PR DESCRIPTION
**Describe the PR**
This PR fixes a bug of the function "reduce_dmatrix" for the implicit 2D analysis.
The dmatrix for 2D should include the 4th row and 4th column of the original dmatrix,
but the previous code uses the 5th row and 5th column.

**Related Issues/PRs**
Nothing.

**Additional context**
Nothing.