### PR TITLE
[Element] B-bar method

### DIFF
--- a/include/particles/particle.h
+++ b/include/particles/particle.h
@@ -196,7 +196,7 @@ class Particle : public ParticleBase<Tdim> {
   void map_body_force(const VectorDim& pgravity) noexcept override;
 
   //! Map internal force
-  inline void map_internal_force() noexcept override;
+  inline void map_internal_force(bool anti_locking) noexcept override;
 
   //! Assign velocity to the particle
   //! \param[in] velocity A vector of particle velocity
@@ -378,19 +378,22 @@ class Particle : public ParticleBase<Tdim> {
 
   //! Map material stiffness matrix to cell (used in equilibrium equation LHS)
   //! \ingroup Implicit
-  inline bool map_material_stiffness_matrix_to_cell() override;
+  //! \param[in] anti_locking Boolean of anti-locking treatment
+  inline bool map_material_stiffness_matrix_to_cell(bool anti_locking) override;
 
   //! Reduce constitutive relations matrix depending on the dimension
   //! \ingroup Implicit
   //! \param[in] dmatrix Constitutive relations matrix in 3D
+  //! \param[in] anti_locking Boolean of anti-locking treatment
   //! \retval reduced_dmatrix Reduced constitutive relation matrix for spatial
   //! dimension
-  inline Eigen::MatrixXd reduce_dmatrix(
-      const Eigen::MatrixXd& dmatrix) noexcept override;
+  inline Eigen::MatrixXd reduce_dmatrix(const Eigen::MatrixXd& dmatrix,
+                                        bool anti_locking) noexcept override;
 
   //! Compute B matrix of a particle, based on local coordinates
   //! \ingroup Implicit
-  inline Eigen::MatrixXd compute_bmatrix() noexcept override;
+  //! \param[in] anti_locking Boolean of anti-locking treatment
+  inline Eigen::MatrixXd compute_bmatrix(bool anti_locking) noexcept override;
 
   //! Map mass matrix to cell (used in equilibrium equation LHS)
   //! \ingroup Implicit

--- a/include/particles/particle.h
+++ b/include/particles/particle.h
@@ -389,6 +389,7 @@ class Particle : public ParticleBase<Tdim> {
       const Eigen::MatrixXd& dmatrix) noexcept override;
 
   //! Compute B matrix of a particle, based on local coordinates
+  //! \ingroup Implicit
   inline Eigen::MatrixXd compute_bmatrix() noexcept override;
 
   //! Map mass matrix to cell (used in equilibrium equation LHS)

--- a/include/particles/particle.h
+++ b/include/particles/particle.h
@@ -158,7 +158,8 @@ class Particle : public ParticleBase<Tdim> {
 
   //! Compute strain
   //! \param[in] dt Analysis time step
-  void compute_strain(double dt) noexcept override;
+  //! \param[in] anti_locking Boolean of anti-locking treatment
+  void compute_strain(double dt, bool anti_locking) noexcept override;
 
   //! Return strain of the particle
   Eigen::Matrix<double, 6, 1> strain() const override { return strain_; }
@@ -196,6 +197,7 @@ class Particle : public ParticleBase<Tdim> {
   void map_body_force(const VectorDim& pgravity) noexcept override;
 
   //! Map internal force
+  //! \param[in] anti_locking Boolean of anti-locking treatment
   inline void map_internal_force(bool anti_locking) noexcept override;
 
   //! Assign velocity to the particle
@@ -403,7 +405,8 @@ class Particle : public ParticleBase<Tdim> {
 
   //! Compute strain using nodal displacement
   //! \ingroup Implicit
-  void compute_strain_newmark() noexcept override;
+  //! \param[in] anti_locking Boolean of anti-locking treatment
+  void compute_strain_newmark(bool anti_locking) noexcept override;
 
   //! Compute stress using implicit updating scheme
   //! \ingroup Implicit
@@ -444,9 +447,10 @@ class Particle : public ParticleBase<Tdim> {
   //! \ingroup Implicit
   //! \param[in] dn_dx The spatial gradient of shape function
   //! \param[in] phase Index to indicate phase
+  //! \param[in] anti_locking Boolean of anti-locking treatment
   //! \retval strain rate at particle inside a cell
   inline Eigen::Matrix<double, 6, 1> compute_strain_rate(
-      const Eigen::MatrixXd& dn_dx, unsigned phase) noexcept;
+      const Eigen::MatrixXd& dn_dx, unsigned phase, bool anti_locking) noexcept;
 
   //! Compute pack size
   //! \retval pack size of serialized object
@@ -460,9 +464,10 @@ class Particle : public ParticleBase<Tdim> {
   //! \ingroup Implicit
   //! \param[in] dn_dx The spatial gradient of shape function
   //! \param[in] phase Index to indicate phase
+  //! \param[in] anti_locking Boolean of anti-locking treatment
   //! \retval strain increment at particle inside a cell
   inline Eigen::Matrix<double, 6, 1> compute_strain_increment(
-      const Eigen::MatrixXd& dn_dx, unsigned phase) noexcept;
+      const Eigen::MatrixXd& dn_dx, unsigned phase, bool anti_locking) noexcept;
   /**@}*/
 
   //! particle id

--- a/include/particles/particle_base.h
+++ b/include/particles/particle_base.h
@@ -251,7 +251,7 @@ class ParticleBase {
   virtual void map_body_force(const VectorDim& pgravity) noexcept = 0;
 
   //! Map internal force
-  virtual void map_internal_force() noexcept = 0;
+  virtual void map_internal_force(bool anti_locking) noexcept = 0;
 
   //! Map particle pressure to nodes
   virtual bool map_pressure_to_nodes(
@@ -366,16 +366,23 @@ class ParticleBase {
 
   //! Map material stiffness matrix to cell (used in equilibrium equation LHS)
   //! \ingroup Implicit
-  virtual inline bool map_material_stiffness_matrix_to_cell() = 0;
+  //! \param[in] anti_locking Boolean of anti-locking treatment
+  virtual inline bool map_material_stiffness_matrix_to_cell(
+      bool anti_locking) = 0;
 
   //! Reduce constitutive relations matrix depending on the dimension
   //! \ingroup Implicit
-  virtual inline Eigen::MatrixXd reduce_dmatrix(
-      const Eigen::MatrixXd& dmatrix) = 0;
+  //! \param[in] dmatrix Constitutive relations matrix in 3D
+  //! \param[in] anti_locking Boolean of anti-locking treatment
+  //! \retval reduced_dmatrix Reduced constitutive relation matrix for spatial
+  //! dimension
+  virtual inline Eigen::MatrixXd reduce_dmatrix(const Eigen::MatrixXd& dmatrix,
+                                                bool anti_locking) = 0;
 
   //! Compute B matrix
   //! \ingroup Implicit
-  virtual inline Eigen::MatrixXd compute_bmatrix() = 0;
+  //! \param[in] anti_locking Boolean of anti-locking treatment
+  virtual inline Eigen::MatrixXd compute_bmatrix(bool anti_locking) = 0;
 
   //! Map mass matrix to cell (used in equilibrium equation LHS)
   //! \ingroup Implicit

--- a/include/particles/particle_base.h
+++ b/include/particles/particle_base.h
@@ -224,7 +224,7 @@ class ParticleBase {
   virtual double pressure(unsigned phase = mpm::ParticlePhase::Solid) const = 0;
 
   //! Compute strain
-  virtual void compute_strain(double dt) noexcept = 0;
+  virtual void compute_strain(double dt, bool anti_locking) noexcept = 0;
 
   //! Strain
   virtual Eigen::Matrix<double, 6, 1> strain() const = 0;
@@ -393,7 +393,8 @@ class ParticleBase {
 
   //! Compute strain using nodal displacement
   //! \ingroup Implicit
-  virtual void compute_strain_newmark() = 0;
+  //! \param[in] anti_locking Boolean of anti-locking treatment
+  virtual void compute_strain_newmark(bool anti_locking) = 0;
 
   //! Compute stress using implicit updating scheme
   //! \ingroup Implicit

--- a/include/particles/particle_base.h
+++ b/include/particles/particle_base.h
@@ -369,10 +369,12 @@ class ParticleBase {
   virtual inline bool map_material_stiffness_matrix_to_cell() = 0;
 
   //! Reduce constitutive relations matrix depending on the dimension
+  //! \ingroup Implicit
   virtual inline Eigen::MatrixXd reduce_dmatrix(
       const Eigen::MatrixXd& dmatrix) = 0;
 
   //! Compute B matrix
+  //! \ingroup Implicit
   virtual inline Eigen::MatrixXd compute_bmatrix() = 0;
 
   //! Map mass matrix to cell (used in equilibrium equation LHS)

--- a/include/particles/particle_fluid.h
+++ b/include/particles/particle_fluid.h
@@ -39,7 +39,7 @@ class FluidParticle : public mpm::Particle<Tdim> {
   void compute_stress() noexcept override;
 
   //! Map internal force
-  inline void map_internal_force() noexcept override;
+  inline void map_internal_force(bool anti_locking) noexcept override;
 
   //! ----------------------------------------------------------------
   //! Semi-Implicit integration functions based on Chorin's Projection

--- a/include/particles/particle_fluid.tcc
+++ b/include/particles/particle_fluid.tcc
@@ -56,7 +56,8 @@ Eigen::Matrix<double, 6, 1>
 
 //! Map internal force
 template <>
-inline void mpm::FluidParticle<1>::map_internal_force() noexcept {
+inline void mpm::FluidParticle<1>::map_internal_force(
+    bool anti_locking) noexcept {
   // initialise a vector of total stress (deviatoric + turbulent - pressure)
   Eigen::Matrix<double, 6, 1> total_stress = this->stress_;
   total_stress(0) -=
@@ -76,7 +77,8 @@ inline void mpm::FluidParticle<1>::map_internal_force() noexcept {
 
 //! Map internal force
 template <>
-inline void mpm::FluidParticle<2>::map_internal_force() noexcept {
+inline void mpm::FluidParticle<2>::map_internal_force(
+    bool anti_locking) noexcept {
   // initialise a vector of total stress (deviatoric + turbulent - pressure)
   Eigen::Matrix<double, 6, 1> total_stress = this->stress_;
   total_stress(0) -=
@@ -102,7 +104,8 @@ inline void mpm::FluidParticle<2>::map_internal_force() noexcept {
 
 //! Map internal force
 template <>
-inline void mpm::FluidParticle<3>::map_internal_force() noexcept {
+inline void mpm::FluidParticle<3>::map_internal_force(
+    bool anti_locking) noexcept {
   // initialise a vector of total stress (deviatoric + turbulent - pressure)
   Eigen::Matrix<double, 6, 1> total_stress = this->stress_;
   total_stress(0) -=

--- a/include/particles/particle_twophase.h
+++ b/include/particles/particle_twophase.h
@@ -80,7 +80,7 @@ class TwoPhaseParticle : public mpm::Particle<Tdim> {
   void map_traction_force() noexcept override;
 
   //! Map internal force
-  inline void map_internal_force() noexcept override;
+  inline void map_internal_force(bool anti_locking) noexcept override;
 
   //! Compute updated position of the particle and kinematics of both solid and
   //! liquid phase \param[in] dt Analysis time step \param[in] velocity_update

--- a/include/particles/particle_twophase.tcc
+++ b/include/particles/particle_twophase.tcc
@@ -462,7 +462,8 @@ void mpm::TwoPhaseParticle<Tdim>::map_liquid_traction_force() noexcept {
 
 //! Map both mixture and liquid internal force
 template <unsigned Tdim>
-inline void mpm::TwoPhaseParticle<Tdim>::map_internal_force() noexcept {
+inline void mpm::TwoPhaseParticle<Tdim>::map_internal_force(
+    bool anti_locking) noexcept {
   mpm::TwoPhaseParticle<Tdim>::map_mixture_internal_force();
   mpm::TwoPhaseParticle<Tdim>::map_liquid_internal_force();
 }

--- a/include/particles/particle_twophase.tcc
+++ b/include/particles/particle_twophase.tcc
@@ -388,11 +388,11 @@ void mpm::TwoPhaseParticle<Tdim>::compute_pore_pressure(double dt) noexcept {
 
   // Compute at centroid
   // get phase-wise strain rate at cell centre
-  auto strain_rate_centroid =
-      this->compute_strain_rate(dn_dx_centroid_, mpm::ParticlePhase::Solid);
+  auto strain_rate_centroid = this->compute_strain_rate(
+      dn_dx_centroid_, mpm::ParticlePhase::Solid, false);
 
-  auto liquid_strain_rate_centroid =
-      this->compute_strain_rate(dn_dx_centroid_, mpm::ParticlePhase::Liquid);
+  auto liquid_strain_rate_centroid = this->compute_strain_rate(
+      dn_dx_centroid_, mpm::ParticlePhase::Liquid, false);
 
   // update pressure
   this->state_variables_[mpm::ParticlePhase::Liquid].at("pressure") +=

--- a/include/solvers/mpm_base.h
+++ b/include/solvers/mpm_base.h
@@ -231,6 +231,8 @@ class MPMBase : public MPM {
   std::shared_ptr<mpm::Contact<Tdim>> contact_{nullptr};
   //! velocity update
   bool velocity_update_{false};
+  //! Anti-locking treatment
+  bool anti_locking_{false};
   //! Gravity
   Eigen::Matrix<double, Tdim, 1> gravity_;
   //! Mesh object

--- a/include/solvers/mpm_base.tcc
+++ b/include/solvers/mpm_base.tcc
@@ -73,6 +73,18 @@ mpm::MPMBase<Tdim>::MPMBase(const std::shared_ptr<IO>& io) : mpm::MPM(io) {
       velocity_update_ = false;
     }
 
+    // Anti-locking treatment
+    try {
+      anti_locking_ = analysis_["anti_locking"].template get<bool>();
+    } catch (std::exception& exception) {
+      console_->warn(
+          "{} #{}: Anti-locking treatment parameter is not specified, using "
+          "default "
+          "as false",
+          __FILE__, __LINE__, exception.what());
+      anti_locking_ = false;
+    }
+
     // Damping
     try {
       if (analysis_.find("damping") != analysis_.end()) {

--- a/include/solvers/mpm_explicit.h
+++ b/include/solvers/mpm_explicit.h
@@ -24,7 +24,8 @@ class MPMExplicit : public MPMBase<Tdim> {
 
   //! Compute stress strain
   //! \param[in] phase Phase to smooth pressure
-  void compute_stress_strain(unsigned phase);
+  //! \param[in] anti_locking Boolean of anti-locking treatment
+  void compute_stress_strain(unsigned phase, bool anti_locking);
 
  protected:
   // Generate a unique id for the analysis

--- a/include/solvers/mpm_explicit.h
+++ b/include/solvers/mpm_explicit.h
@@ -61,6 +61,8 @@ class MPMExplicit : public MPMBase<Tdim> {
 
   //! velocity update
   using mpm::MPMBase<Tdim>::velocity_update_;
+  //! Anti-locking treatment
+  using mpm::MPMBase<Tdim>::anti_locking_;
   //! Gravity
   using mpm::MPMBase<Tdim>::gravity_;
   //! Mesh object

--- a/include/solvers/mpm_explicit.tcc
+++ b/include/solvers/mpm_explicit.tcc
@@ -157,7 +157,7 @@ bool mpm::MPMExplicit<Tdim>::solve() {
 
     // Compute forces
     mpm_scheme_->compute_forces(gravity_, phase, step_,
-                                set_node_concentrated_force_);
+                                set_node_concentrated_force_, anti_locking_);
 
     // Particle kinematics
     mpm_scheme_->compute_particle_kinematics(velocity_update_, phase, "Cundall",

--- a/include/solvers/mpm_explicit_twophase.h
+++ b/include/solvers/mpm_explicit_twophase.h
@@ -54,6 +54,8 @@ class MPMExplicitTwoPhase : public MPMBase<Tdim> {
 
   //! velocity update
   using mpm::MPMBase<Tdim>::velocity_update_;
+  //! Anti-locking treatment
+  using mpm::MPMBase<Tdim>::anti_locking_;
   //! Gravity
   using mpm::MPMBase<Tdim>::gravity_;
   //! Mesh object

--- a/include/solvers/mpm_explicit_twophase.h
+++ b/include/solvers/mpm_explicit_twophase.h
@@ -23,7 +23,8 @@ class MPMExplicitTwoPhase : public MPMBase<Tdim> {
   bool solve() override;
 
   //! Compute stress strain
-  void compute_stress_strain();
+  //! \param[in] anti_locking Boolean of anti-locking treatment
+  void compute_stress_strain(bool anti_locking);
 
  protected:
   // Generate a unique id for the analysis

--- a/include/solvers/mpm_explicit_twophase.tcc
+++ b/include/solvers/mpm_explicit_twophase.tcc
@@ -271,7 +271,7 @@ bool mpm::MPMExplicitTwoPhase<Tdim>::solve() {
         // Iterate over each particle to compute nodal internal force
         mesh_->iterate_over_particles(
             std::bind(&mpm::ParticleBase<Tdim>::map_internal_force,
-                      std::placeholders::_1));
+                      std::placeholders::_1, anti_locking_));
       }
 
 #pragma omp section

--- a/include/solvers/mpm_explicit_twophase.tcc
+++ b/include/solvers/mpm_explicit_twophase.tcc
@@ -9,10 +9,11 @@ mpm::MPMExplicitTwoPhase<Tdim>::MPMExplicitTwoPhase(
 
 //! MPM Explicit compute stress strain
 template <unsigned Tdim>
-void mpm::MPMExplicitTwoPhase<Tdim>::compute_stress_strain() {
+void mpm::MPMExplicitTwoPhase<Tdim>::compute_stress_strain(bool anti_locking) {
   // Iterate over each particle to calculate strain of soil_skeleton
-  mesh_->iterate_over_particles(std::bind(
-      &mpm::ParticleBase<Tdim>::compute_strain, std::placeholders::_1, dt_));
+  mesh_->iterate_over_particles(
+      std::bind(&mpm::ParticleBase<Tdim>::compute_strain, std::placeholders::_1,
+                dt_, anti_locking));
   // Iterate over each particle to update particle volume
   mesh_->iterate_over_particles(std::bind(
       &mpm::ParticleBase<Tdim>::update_volume, std::placeholders::_1));
@@ -241,7 +242,8 @@ bool mpm::MPMExplicitTwoPhase<Tdim>::solve() {
         std::bind(&mpm::NodeBase<Tdim>::status, std::placeholders::_1));
 
     // Update stress first
-    if (this->stress_update_ == "usf") this->compute_stress_strain();
+    if (this->stress_update_ == "usf")
+      this->compute_stress_strain(anti_locking_);
 
       // Spawn a task for external force
 #pragma omp parallel sections
@@ -349,7 +351,8 @@ bool mpm::MPMExplicitTwoPhase<Tdim>::solve() {
     mesh_->apply_particle_velocity_constraints();
 
     // Update Stress Last
-    if (this->stress_update_ == "usl") this->compute_stress_strain();
+    if (this->stress_update_ == "usl")
+      this->compute_stress_strain(anti_locking_);
 
     // Locate particles
     auto unlocatable_particles = mesh_->locate_particles_mesh();

--- a/include/solvers/mpm_implicit.h
+++ b/include/solvers/mpm_implicit.h
@@ -101,6 +101,8 @@ class MPMImplicit : public MPMBase<Tdim> {
 
   //! velocity update
   using mpm::MPMBase<Tdim>::velocity_update_;
+  //! Anti-locking treatment
+  using mpm::MPMBase<Tdim>::anti_locking_;
   //! Gravity
   using mpm::MPMBase<Tdim>::gravity_;
   //! Mesh object

--- a/include/solvers/mpm_implicit.tcc
+++ b/include/solvers/mpm_implicit.tcc
@@ -209,7 +209,8 @@ bool mpm::MPMImplicit<Tdim>::solve() {
                                                    newmark_gamma_);
 
       // Update stress and strain
-      mpm_scheme_->postcompute_stress_strain(phase_, pressure_smoothing_);
+      mpm_scheme_->postcompute_stress_strain(phase_, pressure_smoothing_,
+                                             anti_locking_);
 
       // Check convergence of Newton-Raphson iteration
       if (nonlinear_) {

--- a/include/solvers/mpm_implicit.tcc
+++ b/include/solvers/mpm_implicit.tcc
@@ -390,7 +390,7 @@ bool mpm::MPMImplicit<Tdim>::assemble_system_equation() {
     // Compute local cell stiffness matrices
     mesh_->iterate_over_particles(std::bind(
         &mpm::ParticleBase<Tdim>::map_material_stiffness_matrix_to_cell,
-        std::placeholders::_1));
+        std::placeholders::_1, anti_locking_));
     mesh_->iterate_over_particles(
         std::bind(&mpm::ParticleBase<Tdim>::map_mass_matrix_to_cell,
                   std::placeholders::_1, newmark_beta_, dt_));
@@ -400,7 +400,7 @@ bool mpm::MPMImplicit<Tdim>::assemble_system_equation() {
 
     // Compute local residual force
     mpm_scheme_->compute_forces(gravity_, phase_, step_,
-                                set_node_concentrated_force_);
+                                set_node_concentrated_force_, anti_locking_);
 
     // Assemble global residual force RHS vector
     assembler_->assemble_residual_force_right();

--- a/include/solvers/mpm_scheme/mpm_scheme.h
+++ b/include/solvers/mpm_scheme/mpm_scheme.h
@@ -52,10 +52,11 @@ class MPMScheme {
   //! \param[in] gravity Acceleration due to gravity
   //! \param[in] step Number of step in solver
   //! \param[in] concentrated_nodal_forces Boolean for if a concentrated force
+  //! \param[in] anti_locking Boolean of anti-locking treatment
   //! is applied or not
   virtual inline void compute_forces(
       const Eigen::Matrix<double, Tdim, 1>& gravity, unsigned phase,
-      unsigned step, bool concentrated_nodal_forces);
+      unsigned step, bool concentrated_nodal_forces, bool anti_locking);
 
   //! Compute acceleration velocity position
   //! \param[in] velocity_update Velocity or acceleration update flag

--- a/include/solvers/mpm_scheme/mpm_scheme.h
+++ b/include/solvers/mpm_scheme/mpm_scheme.h
@@ -28,20 +28,26 @@ class MPMScheme {
   //! Compute stress and strain
   //! \param[in] phase Phase to smooth pressure
   //! \param[in] pressure_smoothing Enable or disable pressure smoothing
+  //! \param[in] anti_locking Boolean of anti-locking treatment
   virtual inline void compute_stress_strain(unsigned phase,
-                                            bool pressure_smoothing);
+                                            bool pressure_smoothing,
+                                            bool anti_locking);
 
   //! Precompute stress and strain (empty call)
   //! \param[in] phase Phase to smooth pressure
   //! \param[in] pressure_smoothing Enable or disable pressure smoothing
+  //! \param[in] anti_locking Boolean of anti-locking treatment
   virtual inline void precompute_stress_strain(unsigned phase,
-                                               bool pressure_smoothing) = 0;
+                                               bool pressure_smoothing,
+                                               bool anti_locking) = 0;
 
   //! Postcompute stress and strain (empty call)
   //! \param[in] phase Phase to smooth postssure
   //! \param[in] postssure_smoothing Enable or disable postssure smoothing
+  //! \param[in] anti_locking Boolean of anti-locking treatment
   virtual inline void postcompute_stress_strain(unsigned phase,
-                                                bool pressure_smoothing) = 0;
+                                                bool pressure_smoothing,
+                                                bool anti_locking) = 0;
 
   //! Pressure smoothing
   //! \param[in] phase Phase to smooth pressure

--- a/include/solvers/mpm_scheme/mpm_scheme.tcc
+++ b/include/solvers/mpm_scheme/mpm_scheme.tcc
@@ -71,12 +71,14 @@ inline void mpm::MPMScheme<Tdim>::compute_nodal_kinematics(unsigned phase) {
 
 //! Compute stress and strain
 template <unsigned Tdim>
-inline void mpm::MPMScheme<Tdim>::compute_stress_strain(
-    unsigned phase, bool pressure_smoothing) {
+inline void mpm::MPMScheme<Tdim>::compute_stress_strain(unsigned phase,
+                                                        bool pressure_smoothing,
+                                                        bool anti_locking) {
 
   // Iterate over each particle to calculate strain
-  mesh_->iterate_over_particles(std::bind(
-      &mpm::ParticleBase<Tdim>::compute_strain, std::placeholders::_1, dt_));
+  mesh_->iterate_over_particles(
+      std::bind(&mpm::ParticleBase<Tdim>::compute_strain, std::placeholders::_1,
+                dt_, anti_locking));
 
   // Iterate over each particle to update particle volume
   mesh_->iterate_over_particles(std::bind(

--- a/include/solvers/mpm_scheme/mpm_scheme.tcc
+++ b/include/solvers/mpm_scheme/mpm_scheme.tcc
@@ -118,7 +118,7 @@ inline void mpm::MPMScheme<Tdim>::pressure_smoothing(unsigned phase) {
 template <unsigned Tdim>
 inline void mpm::MPMScheme<Tdim>::compute_forces(
     const Eigen::Matrix<double, Tdim, 1>& gravity, unsigned phase,
-    unsigned step, bool concentrated_nodal_forces) {
+    unsigned step, bool concentrated_nodal_forces, bool anti_locking) {
   // Spawn a task for external force
 #pragma omp parallel sections
   {
@@ -144,8 +144,9 @@ inline void mpm::MPMScheme<Tdim>::compute_forces(
     {
       // Spawn a task for internal force
       // Iterate over each particle to compute nodal internal force
-      mesh_->iterate_over_particles(std::bind(
-          &mpm::ParticleBase<Tdim>::map_internal_force, std::placeholders::_1));
+      mesh_->iterate_over_particles(
+          std::bind(&mpm::ParticleBase<Tdim>::map_internal_force,
+                    std::placeholders::_1, anti_locking));
     }
   }  // Wait for tasks to finish
 

--- a/include/solvers/mpm_scheme/mpm_scheme_musl.h
+++ b/include/solvers/mpm_scheme/mpm_scheme_musl.h
@@ -27,13 +27,17 @@ class MPMSchemeMUSL : public MPMScheme<Tdim> {
   //! Precompute stress
   //! \param[in] phase Phase to smooth postssure
   //! \param[in] postssure_smoothing Enable or disable postssure smoothing
-  virtual inline void precompute_stress_strain(
-      unsigned phase, bool pressure_smoothing) override;
+  //! \param[in] anti_locking Boolean of anti-locking treatment
+  virtual inline void precompute_stress_strain(unsigned phase,
+                                               bool pressure_smoothing,
+                                               bool anti_locking) override;
   //! Postcompute stress
   //! \param[in] phase Phase to smooth postssure
   //! \param[in] postssure_smoothing Enable or disable postssure smoothing
-  virtual inline void postcompute_stress_strain(
-      unsigned phase, bool pressure_smoothing) override;
+  //! \param[in] anti_locking Boolean of anti-locking treatment
+  virtual inline void postcompute_stress_strain(unsigned phase,
+                                                bool pressure_smoothing,
+                                                bool anti_locking) override;
 
   //! Postcompute nodal kinematics - map mass and momentum to nodes
   //! \param[in] phase Phase to smooth pressure

--- a/include/solvers/mpm_scheme/mpm_scheme_musl.tcc
+++ b/include/solvers/mpm_scheme/mpm_scheme_musl.tcc
@@ -7,13 +7,14 @@ mpm::MPMSchemeMUSL<Tdim>::MPMSchemeMUSL(
 //! Precompute stresses and strains
 template <unsigned Tdim>
 inline void mpm::MPMSchemeMUSL<Tdim>::precompute_stress_strain(
-    unsigned phase, bool pressure_smoothing) {}
+    unsigned phase, bool pressure_smoothing, bool anti_locking) {}
 
 //! Postcompute stresses and strains
 template <unsigned Tdim>
 inline void mpm::MPMSchemeMUSL<Tdim>::postcompute_stress_strain(
-    unsigned phase, bool pressure_smoothing) {
-  mpm::MPMScheme<Tdim>::compute_stress_strain(phase, pressure_smoothing);
+    unsigned phase, bool pressure_smoothing, bool anti_locking) {
+  mpm::MPMScheme<Tdim>::compute_stress_strain(phase, pressure_smoothing,
+                                              anti_locking);
 }
 
 //! Postcompute nodal kinematics - map mass and momentum to nodes

--- a/include/solvers/mpm_scheme/mpm_scheme_newmark.h
+++ b/include/solvers/mpm_scheme/mpm_scheme_newmark.h
@@ -46,10 +46,12 @@ class MPMSchemeNewmark : public MPMScheme<Tdim> {
   //! \param[in] gravity Acceleration due to gravity
   //! \param[in] step Number of step in solver
   //! \param[in] concentrated_nodal_forces Boolean for if a concentrated force
+  //! \param[in] anti_locking Boolean of anti-locking treatment
   //! is applied or not
   virtual inline void compute_forces(
       const Eigen::Matrix<double, Tdim, 1>& gravity, unsigned phase,
-      unsigned step, bool concentrated_nodal_forces) override;
+      unsigned step, bool concentrated_nodal_forces,
+      bool anti_locking) override;
 
   //! Compute acceleration velocity position
   //! \param[in] velocity_update Velocity or acceleration update flag

--- a/include/solvers/mpm_scheme/mpm_scheme_newmark.h
+++ b/include/solvers/mpm_scheme/mpm_scheme_newmark.h
@@ -28,19 +28,25 @@ class MPMSchemeNewmark : public MPMScheme<Tdim> {
   //! Compute stress and strain
   //! \param[in] phase Phase to smooth pressure
   //! \param[in] pressure_smoothing Enable or disable pressure smoothing
+  //! \param[in] anti_locking Boolean of anti-locking treatment
   virtual inline void compute_stress_strain(unsigned phase,
-                                            bool pressure_smoothing) override;
+                                            bool pressure_smoothing,
+                                            bool anti_locking) override;
 
   //! Precompute stress
   //! \param[in] phase Phase to smooth postssure
   //! \param[in] postssure_smoothing Enable or disable postssure smoothing
-  virtual inline void precompute_stress_strain(
-      unsigned phase, bool pressure_smoothing) override;
+  //! \param[in] anti_locking Boolean of anti-locking treatment
+  virtual inline void precompute_stress_strain(unsigned phase,
+                                               bool pressure_smoothing,
+                                               bool anti_locking) override;
   //! Postcompute stress
   //! \param[in] phase Phase to smooth postssure
   //! \param[in] postssure_smoothing Enable or disable postssure smoothing
-  virtual inline void postcompute_stress_strain(
-      unsigned phase, bool pressure_smoothing) override;
+  //! \param[in] anti_locking Boolean of anti-locking treatment
+  virtual inline void postcompute_stress_strain(unsigned phase,
+                                                bool pressure_smoothing,
+                                                bool anti_locking) override;
 
   //! Compute forces
   //! \param[in] gravity Acceleration due to gravity

--- a/include/solvers/mpm_scheme/mpm_scheme_newmark.tcc
+++ b/include/solvers/mpm_scheme/mpm_scheme_newmark.tcc
@@ -116,7 +116,7 @@ inline void mpm::MPMSchemeNewmark<Tdim>::postcompute_stress_strain(
 template <unsigned Tdim>
 inline void mpm::MPMSchemeNewmark<Tdim>::compute_forces(
     const Eigen::Matrix<double, Tdim, 1>& gravity, unsigned phase,
-    unsigned step, bool concentrated_nodal_forces) {
+    unsigned step, bool concentrated_nodal_forces, bool anti_locking) {
   // Spawn a task for external force
 #pragma omp parallel sections
   {
@@ -146,8 +146,9 @@ inline void mpm::MPMSchemeNewmark<Tdim>::compute_forces(
     {
       // Spawn a task for internal force
       // Iterate over each particle to compute nodal internal force
-      mesh_->iterate_over_particles(std::bind(
-          &mpm::ParticleBase<Tdim>::map_internal_force, std::placeholders::_1));
+      mesh_->iterate_over_particles(
+          std::bind(&mpm::ParticleBase<Tdim>::map_internal_force,
+                    std::placeholders::_1, anti_locking));
     }
   }  // Wait for tasks to finish
 }

--- a/include/solvers/mpm_scheme/mpm_scheme_newmark.tcc
+++ b/include/solvers/mpm_scheme/mpm_scheme_newmark.tcc
@@ -86,11 +86,12 @@ inline void mpm::MPMSchemeNewmark<Tdim>::update_nodal_kinematics_newmark(
 //! Compute stress and strain by Newmark scheme
 template <unsigned Tdim>
 inline void mpm::MPMSchemeNewmark<Tdim>::compute_stress_strain(
-    unsigned phase, bool pressure_smoothing) {
+    unsigned phase, bool pressure_smoothing, bool anti_locking) {
 
   // Iterate over each particle to calculate strain using nodal displacement
-  mesh_->iterate_over_particles(std::bind(
-      &mpm::ParticleBase<Tdim>::compute_strain_newmark, std::placeholders::_1));
+  mesh_->iterate_over_particles(
+      std::bind(&mpm::ParticleBase<Tdim>::compute_strain_newmark,
+                std::placeholders::_1, anti_locking));
 
   // Pressure smoothing
   if (pressure_smoothing) this->pressure_smoothing(phase);
@@ -103,13 +104,13 @@ inline void mpm::MPMSchemeNewmark<Tdim>::compute_stress_strain(
 //! Precompute stresses and strains
 template <unsigned Tdim>
 inline void mpm::MPMSchemeNewmark<Tdim>::precompute_stress_strain(
-    unsigned phase, bool pressure_smoothing) {}
+    unsigned phase, bool pressure_smoothing, bool anti_locking) {}
 
 //! Postcompute stresses and strains
 template <unsigned Tdim>
 inline void mpm::MPMSchemeNewmark<Tdim>::postcompute_stress_strain(
-    unsigned phase, bool pressure_smoothing) {
-  this->compute_stress_strain(phase, pressure_smoothing);
+    unsigned phase, bool pressure_smoothing, bool anti_locking) {
+  this->compute_stress_strain(phase, pressure_smoothing, anti_locking);
 }
 
 // Compute forces

--- a/include/solvers/mpm_scheme/mpm_scheme_usf.h
+++ b/include/solvers/mpm_scheme/mpm_scheme_usf.h
@@ -21,13 +21,17 @@ class MPMSchemeUSF : public MPMScheme<Tdim> {
   //! Precompute stress
   //! \param[in] phase Phase to smooth postssure
   //! \param[in] postssure_smoothing Enable or disable postssure smoothing
-  virtual inline void precompute_stress_strain(
-      unsigned phase, bool pressure_smoothing) override;
+  //! \param[in] anti_locking Boolean of anti-locking treatment
+  virtual inline void precompute_stress_strain(unsigned phase,
+                                               bool pressure_smoothing,
+                                               bool anti_locking) override;
   //! Postcompute stress
   //! \param[in] phase Phase to smooth postssure
   //! \param[in] postssure_smoothing Enable or disable postssure smoothing
-  virtual inline void postcompute_stress_strain(
-      unsigned phase, bool pressure_smoothing) override;
+  //! \param[in] anti_locking Boolean of anti-locking treatment
+  virtual inline void postcompute_stress_strain(unsigned phase,
+                                                bool pressure_smoothing,
+                                                bool anti_locking) override;
 
   //! Postcompute nodal kinematics - map mass and momentum to nodes
   //! \param[in] phase Phase to smooth pressure

--- a/include/solvers/mpm_scheme/mpm_scheme_usf.tcc
+++ b/include/solvers/mpm_scheme/mpm_scheme_usf.tcc
@@ -7,14 +7,14 @@ mpm::MPMSchemeUSF<Tdim>::MPMSchemeUSF(
 //! Precompute stresses and strains
 template <unsigned Tdim>
 inline void mpm::MPMSchemeUSF<Tdim>::precompute_stress_strain(
-    unsigned phase, bool pressure_smoothing) {
-  this->compute_stress_strain(phase, pressure_smoothing);
+    unsigned phase, bool pressure_smoothing, bool anti_locking) {
+  this->compute_stress_strain(phase, pressure_smoothing, anti_locking);
 }
 
 //! Postcompute stresses and strains
 template <unsigned Tdim>
 inline void mpm::MPMSchemeUSF<Tdim>::postcompute_stress_strain(
-    unsigned phase, bool pressure_smoothing) {}
+    unsigned phase, bool pressure_smoothing, bool anti_locking) {}
 
 //! Postcompute nodal kinematics - map mass and momentum to nodes
 template <unsigned Tdim>

--- a/include/solvers/mpm_scheme/mpm_scheme_usl.h
+++ b/include/solvers/mpm_scheme/mpm_scheme_usl.h
@@ -21,13 +21,17 @@ class MPMSchemeUSL : public MPMScheme<Tdim> {
   //! Precompute stress
   //! \param[in] phase Phase to smooth postssure
   //! \param[in] postssure_smoothing Enable or disable postssure smoothing
-  virtual inline void precompute_stress_strain(
-      unsigned phase, bool pressure_smoothing) override;
+  //! \param[in] anti_locking Boolean of anti-locking treatment
+  virtual inline void precompute_stress_strain(unsigned phase,
+                                               bool pressure_smoothing,
+                                               bool anti_locking) override;
   //! Postcompute stress
   //! \param[in] phase Phase to smooth postssure
   //! \param[in] postssure_smoothing Enable or disable postssure smoothing
-  virtual inline void postcompute_stress_strain(
-      unsigned phase, bool pressure_smoothing) override;
+  //! \param[in] anti_locking Boolean of anti-locking treatment
+  virtual inline void postcompute_stress_strain(unsigned phase,
+                                                bool pressure_smoothing,
+                                                bool anti_locking) override;
 
   //! Postcompute nodal kinematics - map mass and momentum to nodes
   //! \param[in] phase Phase to smooth pressure

--- a/include/solvers/mpm_scheme/mpm_scheme_usl.tcc
+++ b/include/solvers/mpm_scheme/mpm_scheme_usl.tcc
@@ -7,13 +7,14 @@ mpm::MPMSchemeUSL<Tdim>::MPMSchemeUSL(
 //! Precompute stresses and strains
 template <unsigned Tdim>
 inline void mpm::MPMSchemeUSL<Tdim>::precompute_stress_strain(
-    unsigned phase, bool pressure_smoothing) {}
+    unsigned phase, bool pressure_smoothing, bool anti_locking) {}
 
 //! Postcompute stresses and strains
 template <unsigned Tdim>
 inline void mpm::MPMSchemeUSL<Tdim>::postcompute_stress_strain(
-    unsigned phase, bool pressure_smoothing) {
-  mpm::MPMScheme<Tdim>::compute_stress_strain(phase, pressure_smoothing);
+    unsigned phase, bool pressure_smoothing, bool anti_locking) {
+  mpm::MPMScheme<Tdim>::compute_stress_strain(phase, pressure_smoothing,
+                                              anti_locking);
 }
 
 //! Postcompute nodal kinematics - map mass and momentum to nodes

--- a/include/solvers/mpm_semi_implicit_navierstokes.h
+++ b/include/solvers/mpm_semi_implicit_navierstokes.h
@@ -69,6 +69,8 @@ class MPMSemiImplicitNavierStokes : public MPMBase<Tdim> {
   using mpm::MPMBase<Tdim>::stress_update_;
   //! velocity update
   using mpm::MPMBase<Tdim>::velocity_update_;
+  //! Anti-locking treatment
+  using mpm::MPMBase<Tdim>::anti_locking_;
   //! Gravity
   using mpm::MPMBase<Tdim>::gravity_;
   //! Mesh object

--- a/include/solvers/mpm_semi_implicit_navierstokes.tcc
+++ b/include/solvers/mpm_semi_implicit_navierstokes.tcc
@@ -187,8 +187,9 @@ bool mpm::MPMSemiImplicitNavierStokes<Tdim>::solve() {
         std::bind(&mpm::NodeBase<Tdim>::status, std::placeholders::_1));
 
     // Iterate over each particle to compute strain rate
-    mesh_->iterate_over_particles(std::bind(
-        &mpm::ParticleBase<Tdim>::compute_strain, std::placeholders::_1, dt_));
+    mesh_->iterate_over_particles(
+        std::bind(&mpm::ParticleBase<Tdim>::compute_strain,
+                  std::placeholders::_1, dt_, anti_locking_));
 
     // Iterate over each particle to compute shear (deviatoric) stress
     mesh_->iterate_over_particles(std::bind(

--- a/include/solvers/mpm_semi_implicit_navierstokes.tcc
+++ b/include/solvers/mpm_semi_implicit_navierstokes.tcc
@@ -214,7 +214,7 @@ bool mpm::MPMSemiImplicitNavierStokes<Tdim>::solve() {
         // Iterate over each particle to compute nodal internal force
         mesh_->iterate_over_particles(
             std::bind(&mpm::ParticleBase<Tdim>::map_internal_force,
-                      std::placeholders::_1));
+                      std::placeholders::_1, anti_locking_));
       }
     }  // Wait for tasks to finish
 

--- a/include/solvers/mpm_semi_implicit_twophase.h
+++ b/include/solvers/mpm_semi_implicit_twophase.h
@@ -79,6 +79,8 @@ class MPMSemiImplicitTwoPhase : public MPMBase<Tdim> {
   using mpm::MPMBase<Tdim>::stress_update_;
   //! velocity update
   using mpm::MPMBase<Tdim>::velocity_update_;
+  //! Anti-locking treatment
+  using mpm::MPMBase<Tdim>::anti_locking_;
   //! Gravity
   using mpm::MPMBase<Tdim>::gravity_;
   //! Mesh object

--- a/include/solvers/mpm_semi_implicit_twophase.h
+++ b/include/solvers/mpm_semi_implicit_twophase.h
@@ -27,7 +27,8 @@ class MPMSemiImplicitTwoPhase : public MPMBase<Tdim> {
   }
 
   //! Compute stress strain
-  void compute_stress_strain();
+  //! \param[in] anti_locking Boolean of anti-locking treatment
+  void compute_stress_strain(bool anti_locking);
 
   //! Solve
   bool solve() override;

--- a/include/solvers/mpm_semi_implicit_twophase.tcc
+++ b/include/solvers/mpm_semi_implicit_twophase.tcc
@@ -262,7 +262,7 @@ bool mpm::MPMSemiImplicitTwoPhase<Tdim>::solve() {
         // Iterate over each particle to compute nodal internal force
         mesh_->iterate_over_particles(
             std::bind(&mpm::ParticleBase<Tdim>::map_internal_force,
-                      std::placeholders::_1));
+                      std::placeholders::_1, anti_locking_));
       }
 
 #pragma omp section

--- a/tests/cells/cell_implicit_test.cc
+++ b/tests/cells/cell_implicit_test.cc
@@ -163,7 +163,7 @@ TEST_CASE("Implicit Cell is checked for 2D case", "[cell][2D][Implicit]") {
             &state_variables);
     // Reduce constitutive relations matrix depending on the dimension
     Eigen::MatrixXd reduced_dmatrix;
-    reduced_dmatrix = particle->reduce_dmatrix(dmatrix);
+    reduced_dmatrix = particle->reduce_dmatrix(dmatrix, false);
 
     // Values of reduced constitutive relations matrix
     Eigen::Matrix<double, 3, 3> particle_reduced_dmatrix;
@@ -180,7 +180,7 @@ TEST_CASE("Implicit Cell is checked for 2D case", "[cell][2D][Implicit]") {
 
     // Calculate B matrix
     Eigen::MatrixXd bmatrix;
-    bmatrix = particle->compute_bmatrix();
+    bmatrix = particle->compute_bmatrix(false);
 
     // Values of reduced constitutive relations matrix
     Eigen::Matrix<double, 3, 8> particle_bmatrix;
@@ -420,7 +420,7 @@ TEST_CASE("Implicit Cell is checked for 3D case", "[cell][3D][Implicit]") {
             &state_variables);
     // Reduce constitutive relations matrix depending on the dimension
     Eigen::MatrixXd reduced_dmatrix;
-    reduced_dmatrix = particle->reduce_dmatrix(dmatrix);
+    reduced_dmatrix = particle->reduce_dmatrix(dmatrix, false);
 
     // Values of reduced constitutive relations matrix
     Eigen::Matrix<double, 6, 6> particle_reduced_dmatrix;
@@ -440,7 +440,7 @@ TEST_CASE("Implicit Cell is checked for 3D case", "[cell][3D][Implicit]") {
 
     // Calculate B matrix
     Eigen::MatrixXd bmatrix;
-    bmatrix = particle->compute_bmatrix();
+    bmatrix = particle->compute_bmatrix(false);
 
     // Values of reduced constitutive relations matrix
     Eigen::Matrix<double, 6, 24> particle_bmatrix;

--- a/tests/materials/bingham_test.cc
+++ b/tests/materials/bingham_test.cc
@@ -139,7 +139,7 @@ TEST_CASE("Bingham is checked in 2D", "[material][bingham][2D]") {
     particle->assign_cell(cell);
     particle->assign_material(material);
     particle->compute_shapefn();
-    particle->compute_strain(dt);
+    particle->compute_strain(dt, false);
 
     // Initialise dstrain
     mpm::Material<Dim>::Vector6d dstrain;
@@ -231,7 +231,7 @@ TEST_CASE("Bingham is checked in 2D", "[material][bingham][2D]") {
     particle->assign_cell(cell);
     particle->assign_material(material);
     particle->compute_shapefn();
-    particle->compute_strain(dt);
+    particle->compute_strain(dt, false);
 
     // Initialise dstrain
     mpm::Material<Dim>::Vector6d dstrain;
@@ -325,7 +325,7 @@ TEST_CASE("Bingham is checked in 2D", "[material][bingham][2D]") {
     particle->assign_cell(cell);
     particle->assign_material(material);
     particle->compute_shapefn();
-    particle->compute_strain(dt);
+    particle->compute_strain(dt, false);
 
     // Initialise dstrain
     mpm::Material<Dim>::Vector6d dstrain;
@@ -428,7 +428,7 @@ TEST_CASE("Bingham is checked in 2D", "[material][bingham][2D]") {
     particle->assign_cell(cell);
     particle->assign_material(material);
     particle->compute_shapefn();
-    particle->compute_strain(dt);
+    particle->compute_strain(dt, false);
 
     // Initialise dstrain
     mpm::Material<Dim>::Vector6d dstrain;
@@ -604,7 +604,7 @@ TEST_CASE("Bingham is checked in 3D", "[material][bingham][3D]") {
     particle->assign_cell(cell);
     particle->assign_material(material);
     particle->compute_shapefn();
-    particle->compute_strain(dt);
+    particle->compute_strain(dt, false);
 
     // Initialise dstrain
     mpm::Material<Dim>::Vector6d dstrain;
@@ -706,7 +706,7 @@ TEST_CASE("Bingham is checked in 3D", "[material][bingham][3D]") {
     particle->assign_cell(cell);
     particle->assign_material(material);
     particle->compute_shapefn();
-    particle->compute_strain(dt);
+    particle->compute_strain(dt, false);
 
     // Initialise dstrain
     mpm::Material<Dim>::Vector6d dstrain;
@@ -816,7 +816,7 @@ TEST_CASE("Bingham is checked in 3D", "[material][bingham][3D]") {
     particle->assign_cell(cell);
     particle->assign_material(material);
     particle->compute_shapefn();
-    particle->compute_strain(dt);
+    particle->compute_strain(dt, false);
 
     // Initialise dstrain
     mpm::Material<Dim>::Vector6d dstrain;
@@ -936,7 +936,7 @@ TEST_CASE("Bingham is checked in 3D", "[material][bingham][3D]") {
     particle->assign_cell(cell);
     particle->assign_material(material);
     particle->compute_shapefn();
-    particle->compute_strain(dt);
+    particle->compute_strain(dt, false);
 
     // Initialise dstrain
     mpm::Material<Dim>::Vector6d dstrain;

--- a/tests/materials/newtonian_test.cc
+++ b/tests/materials/newtonian_test.cc
@@ -135,7 +135,7 @@ TEST_CASE("Newtonian is checked in 2D", "[material][newtonian][2D]") {
     particle->assign_cell(cell);
     particle->assign_material(material);
     particle->compute_shapefn();
-    particle->compute_strain(dt);
+    particle->compute_strain(dt, false);
 
     // Initialise dstrain
     mpm::Material<Dim>::Vector6d dstrain;
@@ -230,7 +230,7 @@ TEST_CASE("Newtonian is checked in 2D", "[material][newtonian][2D]") {
     particle->assign_cell(cell);
     particle->assign_material(material);
     particle->compute_shapefn();
-    particle->compute_strain(dt);
+    particle->compute_strain(dt, false);
 
     // Initialise dstrain
     mpm::Material<Dim>::Vector6d dstrain;
@@ -401,7 +401,7 @@ TEST_CASE("Newtonian is checked in 3D", "[material][newtonian][3D]") {
     particle->assign_cell(cell);
     particle->assign_material(material);
     particle->compute_shapefn();
-    particle->compute_strain(dt);
+    particle->compute_strain(dt, false);
 
     // Initialise dstrain
     mpm::Material<Dim>::Vector6d dstrain;
@@ -513,7 +513,7 @@ TEST_CASE("Newtonian is checked in 3D", "[material][newtonian][3D]") {
     particle->assign_cell(cell);
     particle->assign_material(material);
     particle->compute_shapefn();
-    particle->compute_strain(dt);
+    particle->compute_strain(dt, false);
 
     // Initialise dstrain
     mpm::Material<Dim>::Vector6d dstrain;

--- a/tests/particles/particle_implicit_test.cc
+++ b/tests/particles/particle_implicit_test.cc
@@ -294,7 +294,7 @@ TEST_CASE("Implicit Particle is checked for 2D case",
     REQUIRE(std::isnan(particle->pressure()) == true);
 
     // Compute strain increment
-    particle->compute_strain_newmark();
+    particle->compute_strain_newmark(false);
 
     // Compute stress
     REQUIRE_NOTHROW(particle->compute_stress_newmark());
@@ -747,7 +747,7 @@ TEST_CASE("Implicit Particle is checked for 3D case",
     REQUIRE(std::isnan(particle->pressure()) == true);
 
     // Compute strain increment
-    particle->compute_strain_newmark();
+    particle->compute_strain_newmark(false);
 
     // Compute stress
     REQUIRE_NOTHROW(particle->compute_stress_newmark());

--- a/tests/particles/particle_test.cc
+++ b/tests/particles/particle_test.cc
@@ -1107,7 +1107,7 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
 
     // Map particle internal force
     particle->assign_volume(1.0);
-    particle->map_internal_force();
+    particle->map_internal_force(false);
 
     // Check nodal internal force
     for (unsigned i = 0; i < internal_force.rows(); ++i)
@@ -2504,7 +2504,7 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
 
     // Map particle internal force
     particle->assign_volume(8.0);
-    particle->map_internal_force();
+    particle->map_internal_force(false);
 
     // Check nodal internal force
     for (unsigned i = 0; i < internal_force.rows(); ++i)

--- a/tests/particles/particle_test.cc
+++ b/tests/particles/particle_test.cc
@@ -994,7 +994,7 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
     REQUIRE(std::isnan(particle->pressure()) == true);
 
     // Compute strain
-    particle->compute_strain(dt);
+    particle->compute_strain(dt, false);
     // Strain
     Eigen::Matrix<double, 6, 1> strain;
     strain << 0., 0.25, 0., 0.050, 0., 0.;
@@ -1013,7 +1013,7 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
 
     // Update volume strain rate
     REQUIRE(particle->volume() == Approx(1.0).epsilon(Tolerance));
-    particle->compute_strain(dt);
+    particle->compute_strain(dt, false);
     REQUIRE_NOTHROW(particle->update_volume());
     REQUIRE(particle->volume() == Approx(1.2).epsilon(Tolerance));
 
@@ -2380,7 +2380,7 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     REQUIRE(std::isnan(particle->pressure()) == true);
 
     // Compute strain
-    particle->compute_strain(dt);
+    particle->compute_strain(dt, false);
     // Strain
     Eigen::Matrix<double, 6, 1> strain;
     strain << 0.00000, 0.07500, 0.40000, -0.02500, 0.35000, -0.05000;
@@ -2399,7 +2399,7 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
 
     // Update volume strain rate
     REQUIRE(particle->volume() == Approx(8.0).epsilon(Tolerance));
-    particle->compute_strain(dt);
+    particle->compute_strain(dt, false);
     REQUIRE_NOTHROW(particle->update_volume());
     REQUIRE(particle->volume() == Approx(12.0).epsilon(Tolerance));
 

--- a/tests/particles/particle_twophase_test.cc
+++ b/tests/particles/particle_twophase_test.cc
@@ -1010,7 +1010,7 @@ TEST_CASE("TwoPhase Particle is checked for 2D case",
     REQUIRE(std::isnan(particle->pressure()) == true);
 
     // Compute strain
-    particle->compute_strain(dt);
+    particle->compute_strain(dt, false);
     // Strain
     Eigen::Matrix<double, 6, 1> strain;
     strain << 0., 0.25, 0., 0.050, 0., 0.;
@@ -1029,7 +1029,7 @@ TEST_CASE("TwoPhase Particle is checked for 2D case",
 
     // Update volume strain rate
     REQUIRE(particle->volume() == Approx(1.0).epsilon(Tolerance));
-    particle->compute_strain(dt);
+    particle->compute_strain(dt, false);
     REQUIRE_NOTHROW(particle->update_volume());
     REQUIRE(particle->volume() == Approx(1.2).epsilon(Tolerance));
 
@@ -2460,7 +2460,7 @@ TEST_CASE("TwoPhase Particle is checked for 3D case",
     REQUIRE(std::isnan(particle->pressure()) == true);
 
     // Compute strain
-    particle->compute_strain(dt);
+    particle->compute_strain(dt, false);
     // Strain
     Eigen::Matrix<double, 6, 1> strain;
     strain << 0.00000, 0.07500, 0.40000, -0.02500, 0.35000, -0.05000;
@@ -2479,7 +2479,7 @@ TEST_CASE("TwoPhase Particle is checked for 3D case",
 
     // Update volume strain rate
     REQUIRE(particle->volume() == Approx(8.0).epsilon(Tolerance));
-    particle->compute_strain(dt);
+    particle->compute_strain(dt, false);
     REQUIRE_NOTHROW(particle->update_volume());
     REQUIRE(particle->volume() == Approx(12.0).epsilon(Tolerance));
 

--- a/tests/particles/particle_twophase_test.cc
+++ b/tests/particles/particle_twophase_test.cc
@@ -1128,7 +1128,7 @@ TEST_CASE("TwoPhase Particle is checked for 2D case",
 
     // Map particle internal force
     particle->assign_volume(1.0);
-    particle->map_internal_force();
+    particle->map_internal_force(false);
 
     // Check nodal internal force
     for (unsigned i = 0; i < internal_force.rows(); ++i)
@@ -2591,7 +2591,7 @@ TEST_CASE("TwoPhase Particle is checked for 3D case",
 
     // Map particle internal force
     particle->assign_volume(8.0);
-    particle->map_internal_force();
+    particle->map_internal_force(false);
 
     // Check nodal internal force
     for (unsigned i = 0; i < internal_force.rows(); ++i)

--- a/tests/solvers/mpm_scheme_test.cc
+++ b/tests/solvers/mpm_scheme_test.cc
@@ -188,8 +188,8 @@ TEST_CASE("Stress update is checked for USF, USL and MUSL",
     REQUIRE_NOTHROW(mpm_scheme->compute_nodal_kinematics(phase));
 
     // Update stress first
-    REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(phase, false));
-    REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(phase, true));
+    REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(phase, false, false));
+    REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(phase, true, false));
 
     // Compute forces
     REQUIRE_NOTHROW(
@@ -208,8 +208,8 @@ TEST_CASE("Stress update is checked for USF, USL and MUSL",
         mpm_scheme->compute_particle_kinematics(false, phase, "None", 0.02));
 
     // Update Stress Last
-    REQUIRE_NOTHROW(mpm_scheme->postcompute_stress_strain(phase, true));
-    REQUIRE_NOTHROW(mpm_scheme->postcompute_stress_strain(phase, false));
+    REQUIRE_NOTHROW(mpm_scheme->postcompute_stress_strain(phase, true, false));
+    REQUIRE_NOTHROW(mpm_scheme->postcompute_stress_strain(phase, false, false));
 
     // Locate particles
     REQUIRE_NOTHROW(mpm_scheme->locate_particles(true));
@@ -231,8 +231,8 @@ TEST_CASE("Stress update is checked for USF, USL and MUSL",
     REQUIRE_NOTHROW(mpm_scheme->compute_nodal_kinematics(phase));
 
     // Update stress first
-    REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(phase, false));
-    REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(phase, true));
+    REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(phase, false, false));
+    REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(phase, true, false));
 
     // Compute forces
     REQUIRE_NOTHROW(
@@ -251,8 +251,8 @@ TEST_CASE("Stress update is checked for USF, USL and MUSL",
         mpm_scheme->compute_particle_kinematics(false, phase, "None", 0.02));
 
     // Update Stress Last
-    REQUIRE_NOTHROW(mpm_scheme->postcompute_stress_strain(phase, true));
-    REQUIRE_NOTHROW(mpm_scheme->postcompute_stress_strain(phase, false));
+    REQUIRE_NOTHROW(mpm_scheme->postcompute_stress_strain(phase, true, false));
+    REQUIRE_NOTHROW(mpm_scheme->postcompute_stress_strain(phase, false, false));
 
     // Locate particles
     REQUIRE_NOTHROW(mpm_scheme->locate_particles(true));
@@ -274,8 +274,8 @@ TEST_CASE("Stress update is checked for USF, USL and MUSL",
     REQUIRE_NOTHROW(mpm_scheme->compute_nodal_kinematics(phase));
 
     // Update stress first
-    REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(phase, false));
-    REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(phase, true));
+    REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(phase, false, false));
+    REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(phase, true, false));
 
     // Compute forces
     REQUIRE_NOTHROW(
@@ -294,8 +294,8 @@ TEST_CASE("Stress update is checked for USF, USL and MUSL",
         mpm_scheme->compute_particle_kinematics(false, phase, "None", 0.02));
 
     // Update Stress Last
-    REQUIRE_NOTHROW(mpm_scheme->postcompute_stress_strain(phase, true));
-    REQUIRE_NOTHROW(mpm_scheme->postcompute_stress_strain(phase, false));
+    REQUIRE_NOTHROW(mpm_scheme->postcompute_stress_strain(phase, true, false));
+    REQUIRE_NOTHROW(mpm_scheme->postcompute_stress_strain(phase, false, false));
 
     // Locate particles
     REQUIRE_NOTHROW(mpm_scheme->locate_particles(true));
@@ -321,8 +321,8 @@ TEST_CASE("Stress update is checked for USF, USL and MUSL",
     REQUIRE_NOTHROW(mpm_scheme->compute_nodal_kinematics(phase));
 
     // Update stress first
-    REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(phase, false));
-    REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(phase, true));
+    REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(phase, false, false));
+    REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(phase, true, false));
 
     // Compute forces
     REQUIRE_NOTHROW(
@@ -335,8 +335,8 @@ TEST_CASE("Stress update is checked for USF, USL and MUSL",
         mpm_scheme->compute_particle_kinematics(true, phase, "None", 0.02));
 
     // Update Stress Last
-    REQUIRE_NOTHROW(mpm_scheme->postcompute_stress_strain(phase, true));
-    REQUIRE_NOTHROW(mpm_scheme->postcompute_stress_strain(phase, false));
+    REQUIRE_NOTHROW(mpm_scheme->postcompute_stress_strain(phase, true, false));
+    REQUIRE_NOTHROW(mpm_scheme->postcompute_stress_strain(phase, false, false));
 
     // Locate particles
     REQUIRE_NOTHROW(mpm_scheme->locate_particles(true));

--- a/tests/solvers/mpm_scheme_test.cc
+++ b/tests/solvers/mpm_scheme_test.cc
@@ -192,8 +192,10 @@ TEST_CASE("Stress update is checked for USF, USL and MUSL",
     REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(phase, true));
 
     // Compute forces
-    REQUIRE_NOTHROW(mpm_scheme->compute_forces(gravity, phase, step, false));
-    REQUIRE_NOTHROW(mpm_scheme->compute_forces(gravity, phase, step, true));
+    REQUIRE_NOTHROW(
+        mpm_scheme->compute_forces(gravity, phase, step, false, false));
+    REQUIRE_NOTHROW(
+        mpm_scheme->compute_forces(gravity, phase, step, true, false));
 
     // Particle kinematics
     REQUIRE_NOTHROW(
@@ -233,8 +235,10 @@ TEST_CASE("Stress update is checked for USF, USL and MUSL",
     REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(phase, true));
 
     // Compute forces
-    REQUIRE_NOTHROW(mpm_scheme->compute_forces(gravity, phase, step, false));
-    REQUIRE_NOTHROW(mpm_scheme->compute_forces(gravity, phase, step, true));
+    REQUIRE_NOTHROW(
+        mpm_scheme->compute_forces(gravity, phase, step, false, false));
+    REQUIRE_NOTHROW(
+        mpm_scheme->compute_forces(gravity, phase, step, true, false));
 
     // Particle kinematics
     REQUIRE_NOTHROW(
@@ -274,8 +278,10 @@ TEST_CASE("Stress update is checked for USF, USL and MUSL",
     REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(phase, true));
 
     // Compute forces
-    REQUIRE_NOTHROW(mpm_scheme->compute_forces(gravity, phase, step, false));
-    REQUIRE_NOTHROW(mpm_scheme->compute_forces(gravity, phase, step, true));
+    REQUIRE_NOTHROW(
+        mpm_scheme->compute_forces(gravity, phase, step, false, false));
+    REQUIRE_NOTHROW(
+        mpm_scheme->compute_forces(gravity, phase, step, true, false));
 
     // Particle kinematics
     REQUIRE_NOTHROW(
@@ -319,8 +325,10 @@ TEST_CASE("Stress update is checked for USF, USL and MUSL",
     REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(phase, true));
 
     // Compute forces
-    REQUIRE_NOTHROW(mpm_scheme->compute_forces(gravity, phase, step, false));
-    REQUIRE_NOTHROW(mpm_scheme->compute_forces(gravity, phase, step, true));
+    REQUIRE_NOTHROW(
+        mpm_scheme->compute_forces(gravity, phase, step, false, false));
+    REQUIRE_NOTHROW(
+        mpm_scheme->compute_forces(gravity, phase, step, true, false));
 
     // Particle kinematics
     REQUIRE_NOTHROW(


### PR DESCRIPTION
**Describe the PR**
This PR adds the B-bar method for the infinitesimal strain formulation.
The main features of this PR are as follows.
1. Selective reduced integration by the B-bar method is implemented as an anti-locking treatment.
2. The B-bar method is introduced to the computations of internal force (explicit and implicit), strain rate (explicit), strain increment (implicit), and material stiffness matrix (implicit).
3. For the internal force and strain rate/increment, the equations to compute those variables are modified using dn_dx_centroid_ of each particle.
4. For the material stiffness matrix computation, the full B-bar matrix is constructed.
5. The B-bar method in 2D considers the normal stress and strain in the z-direction. So the size of the B-bar matrix is 4x(2*number of nodes per element).
6. `input.json` is expected to look like the following.
```
	"analysis": {
		"type": "MPMImplicit2D",
		"mpm_scheme": "newmark",
		"anti_locking": true,
                ...
	}
```
Here,
- `"anti_locking"`: Boolean for switching the use of anti-locking treatment (currently B-bar method only).
7. The boolean "anti_locking" is passed from MPMBase class to MPMScheme class and Particle class.

**Related Issues/PRs**
#29 

**Additional context**
This PR refers to the following paper.
Reference
Hughes, T. J. R.: Generalization of selective integration procedures to anisotropic and nonlinear media, Int. J. Numer. Methods Eng., Vol. 15, No. 9, pp. 1413-1418, 1980.