### PR TITLE
[Fix] Remove unnecessary zeros

### DIFF
--- a/include/materials/modified_cam_clay.tcc
+++ b/include/materials/modified_cam_clay.tcc
@@ -189,12 +189,10 @@ Eigen::Matrix<double, 6, 6> mpm::ModifiedCamClay<Tdim>::compute_elastic_tensor(
   // Compute elastic stiffness matrix
   // clang-format off
   Matrix6x6 de = Matrix6x6::Zero();
-  de(0,0)=a1;    de(0,1)=a2;    de(0,2)=a2;    de(0,3)=0;    de(0,4)=0;    de(0,5)=0;
-  de(1,0)=a2;    de(1,1)=a1;    de(1,2)=a2;    de(1,3)=0;    de(1,4)=0;    de(1,5)=0;
-  de(2,0)=a2;    de(2,1)=a2;    de(2,2)=a1;    de(2,3)=0;    de(2,4)=0;    de(2,5)=0;
-  de(3,0)= 0;    de(3,1)= 0;    de(3,2)= 0;    de(3,3)=G;    de(3,4)=0;    de(3,5)=0;
-  de(4,0)= 0;    de(4,1)= 0;    de(4,2)= 0;    de(4,3)=0;    de(4,4)=G;    de(4,5)=0;
-  de(5,0)= 0;    de(5,1)= 0;    de(5,2)= 0;    de(5,3)=0;    de(5,4)=0;    de(5,5)=G;
+  de(0,0)=a1;    de(0,1)=a2;    de(0,2)=a2;
+  de(1,0)=a2;    de(1,1)=a1;    de(1,2)=a2;
+  de(2,0)=a2;    de(2,1)=a2;    de(2,2)=a1;
+  de(3,3)=G;     de(4,4)=G;     de(5,5)=G;
   // clang-format on
   return de;
 }

--- a/include/materials/norsand.tcc
+++ b/include/materials/norsand.tcc
@@ -184,12 +184,10 @@ Eigen::Matrix<double, 6, 6> mpm::NorSand<Tdim>::compute_elastic_tensor(
   // compute elastic stiffness matrix
   // clang-format off
   Matrix6x6 de = Matrix6x6::Zero();
-  de(0,0)=a1;    de(0,1)=a2;    de(0,2)=a2;    de(0,3)=0;    de(0,4)=0;    de(0,5)=0;
-  de(1,0)=a2;    de(1,1)=a1;    de(1,2)=a2;    de(1,3)=0;    de(1,4)=0;    de(1,5)=0;
-  de(2,0)=a2;    de(2,1)=a2;    de(2,2)=a1;    de(2,3)=0;    de(2,4)=0;    de(2,5)=0;
-  de(3,0)= 0;    de(3,1)= 0;    de(3,2)= 0;    de(3,3)=G;    de(3,4)=0;    de(3,5)=0;
-  de(4,0)= 0;    de(4,1)= 0;    de(4,2)= 0;    de(4,3)=0;    de(4,4)=G;    de(4,5)=0;
-  de(5,0)= 0;    de(5,1)= 0;    de(5,2)= 0;    de(5,3)=0;    de(5,4)=0;    de(5,5)=G;
+  de(0,0)=a1;    de(0,1)=a2;    de(0,2)=a2;
+  de(1,0)=a2;    de(1,1)=a1;    de(1,2)=a2;
+  de(2,0)=a2;    de(2,1)=a2;    de(2,2)=a1;
+  de(3,3)=G;     de(4,4)=G;     de(5,5)=G;
   // clang-format on
 
   return de;

--- a/include/solvers/mpm_base.tcc
+++ b/include/solvers/mpm_base.tcc
@@ -829,7 +829,8 @@ bool mpm::MPMBase<Tdim>::initialise_math_functions(const Json& math_functions) {
       // Create a file reader
       const std::string io_type =
           io_->json_object("mesh")["io_type"].template get<std::string>();
-      const auto& reader = Factory<mpm::IOMesh<Tdim>>::instance()->create(io_type);
+      const auto& reader =
+          Factory<mpm::IOMesh<Tdim>>::instance()->create(io_type);
 
       // Math function is specified in a file, replace function_props_update
       if (function_props.find("file") != function_props.end()) {


### PR DESCRIPTION
**Describe the PR**
Remove unecessary zeros from `compute_elastic_tensor(...)` in NorSand and Modified Cam Clay models. 

Quick calculations show that current implementation is about `1.5x` times slower than the proposed improvements. 
>This is approximated by tracking time to complete 1,000,000 function calls with and without the extra zero assignment. The 1,000,000 function calls was completed for 10 sets and averaged.
>```
>1000000 function calls per set
>10 sets
>
>average run time                  : 2174.55 [ms]
>average run time (explicit zeros) : 3433.09 [ms]
>```

**Related Issues/PRs**
None

**Additional context**
None