### PR TITLE
[Particle] Several enhancement of particle finite strains

### DIFF
--- a/include/particles/particle_finite_strain.h
+++ b/include/particles/particle_finite_strain.h
@@ -48,6 +48,9 @@ class ParticleFiniteStrain : public mpm::Particle<Tdim> {
   //! Type of particle
   std::string type() const override { return (Tdim == 2) ? "P2DFS" : "P3DFS"; }
 
+  //! Compute shape functions of a particle, based on local coordinates
+  void compute_shapefn() noexcept override;
+
   //! Return strain of the particle
   Eigen::Matrix<double, 6, 1> strain() const override {
     const auto& strain = this->compute_hencky_strain();
@@ -142,6 +145,8 @@ class ParticleFiniteStrain : public mpm::Particle<Tdim> {
   using Particle<Tdim>::mass_density_;
   //! Stresses
   using Particle<Tdim>::stress_;
+  //! Stresses at the previous time step
+  using Particle<Tdim>::previous_stress_;
   //! Velocity
   using Particle<Tdim>::velocity_;
   //! Acceleration
@@ -159,14 +164,6 @@ class ParticleFiniteStrain : public mpm::Particle<Tdim> {
   std::unique_ptr<spdlog::logger> console_;
 
   /**
-   * \defgroup ImplicitVariables Variables dealing with implicit MPM
-   */
-  /**@{*/
-  //! Stresses at the last time step
-  Eigen::Matrix<double, 6, 1> previous_stress_;
-  /**@}*/
-
-  /**
    * \defgroup FiniteStrainVariables Variables for finite strain formulation
    */
   /**@{*/
@@ -175,6 +172,8 @@ class ParticleFiniteStrain : public mpm::Particle<Tdim> {
   //! Deformation gradient increment
   Eigen::Matrix<double, 3, 3> deformation_gradient_increment_{
       Eigen::Matrix<double, 3, 3>::Identity()};
+  //! Shape function gradient at the reference configuration
+  Eigen::MatrixXd reference_dn_dx_;
   /**@}*/
 
 };  // ParticleFiniteStrain class


### PR DESCRIPTION
**Describe the PR**
This PR adds (rather minor) enhancements to the finite-strain analysis as follow:
1. Correction in dn_dx in large deformation. As suggested by @migmolper, I am adding a recomputation process of `dn_dx_` at each iteration, by multiplying the `reference_dn_dx_` with the computed `deformation_gradient_increment_`. For a very large time step (dt=0.1s), it is shown to slightly improve the convergence rate in a 3D beam problem.
- Current code: 10 iterations/step (threshold)
- Proposed code: 7/8 iterations/step

The obtained results also slightly conserve the energy better (comparison is coming).


**Related Issues/PRs**
PR https://github.com/geomechanics/mpm/pull/45.

**Additional context**
I am opening this PR for further discussions.
