### PR TITLE
[Bug] Water table initialization

### DIFF
--- a/include/particles/particle_base.h
+++ b/include/particles/particle_base.h
@@ -507,6 +507,11 @@ class ParticleBase {
   };
 
   //! Initialise particle pore pressure by watertable
+  //! \param[in] dir_v Vertical direction (Gravity direction) of the watertable
+  //! \param[in] dir_h Horizontal direction of the watertable
+  //! \param[in] gravity Gravity vector
+  //! \param[in] reference_points
+  //! (Horizontal coordinate of borehole + height of 0 pore pressure)
   virtual bool initialise_pore_pressure_watertable(
       const unsigned dir_v, const unsigned dir_h, const VectorDim& gravity,
       std::map<double, double>& reference_points) {

--- a/tests/io/write_mesh_particles.cc
+++ b/tests/io/write_mesh_particles.cc
@@ -1195,6 +1195,16 @@ bool write_json_twophase(unsigned dim, bool resume, const std::string& analysis,
         {"vtk_statevars", {{{"phase_id", 0}, {"statevars", {"pdstrain"}}}}},
         {"output_steps", 5}}}};
 
+  if (dim == 3) {
+    Json water_table = {{{"position", 0.0}, {"h0", 0.0}},
+                        {{"position", 1.0}, {"h0", 0.0}}};
+
+    json_file["mesh"]["particles_pore_pressures"]["type"] = "water_table";
+    json_file["mesh"]["particles_pore_pressures"]["dir_v"] = 1;
+    json_file["mesh"]["particles_pore_pressures"]["dir_h"] = 0;
+    json_file["mesh"]["particles_pore_pressures"]["water_tables"] = water_table;
+  }
+
   // Dump JSON as an input file to be read
   std::ofstream file;
   file.open((file_name + "-" + dimension + ".json").c_str());


### PR DESCRIPTION
**Describe the PR**
There is a bug to initialise pore pressure with the water table. The previous code passed `gravity_` which was not yet initialized by the `initialise_loads()` function. The proposed code reads gravity from the exact location as the load if desired by the initializer.

**Related Issues/PRs**
N/A

**Additional context**
I added an extra test to check the initialization.
