### PR TITLE
[MPI] Two-phase semi-implicit Issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,6 +276,7 @@ if(MPM_BUILD_TESTING)
     ${mpm_SOURCE_DIR}/tests/particles/particle_twophase_test.cc
     ${mpm_SOURCE_DIR}/tests/particles/particle_traction_test.cc
     ${mpm_SOURCE_DIR}/tests/particles/particle_vector_test.cc
+    ${mpm_SOURCE_DIR}/tests/particles/particle_serialize_deserialize_fluid_test.cc
     ${mpm_SOURCE_DIR}/tests/particles/particle_serialize_deserialize_test.cc
     ${mpm_SOURCE_DIR}/tests/particles/particle_serialize_deserialize_twophase_test.cc
     ${mpm_SOURCE_DIR}/tests/point_in_cell_test.cc

--- a/include/particles/particle_base.h
+++ b/include/particles/particle_base.h
@@ -429,7 +429,7 @@ class ParticleBase {
   };
 
   //! Return projection parameter
-  virtual double projection_param() const {
+  virtual double projection_parameter() const {
     throw std::runtime_error(
         "Calling the base class function (projection_param) in "
         "ParticleBase:: illegal operation!");

--- a/include/particles/particle_base.h
+++ b/include/particles/particle_base.h
@@ -428,6 +428,14 @@ class ParticleBase {
         "ParticleBase:: illegal operation!");
   };
 
+  //! Return projection parameter
+  virtual double projection_param() const {
+    throw std::runtime_error(
+        "Calling the base class function (projection_param) in "
+        "ParticleBase:: illegal operation!");
+    return 0;
+  };
+
   //! Map laplacian element matrix to cell (used in poisson equation LHS)
   virtual bool map_laplacian_to_cell() {
     throw std::runtime_error(

--- a/include/particles/particle_fluid.h
+++ b/include/particles/particle_fluid.h
@@ -63,7 +63,7 @@ class FluidParticle : public mpm::Particle<Tdim> {
   };
 
   //! Return projection parameter
-  double projection_param() const override { return this->projection_param_; }
+  double projection_parameter() const override { return this->projection_param_; }
 
   //! Map laplacian element matrix to cell (used in poisson equation LHS)
   bool map_laplacian_to_cell() override;

--- a/include/particles/particle_fluid.h
+++ b/include/particles/particle_fluid.h
@@ -63,7 +63,9 @@ class FluidParticle : public mpm::Particle<Tdim> {
   };
 
   //! Return projection parameter
-  double projection_parameter() const override { return this->projection_param_; }
+  double projection_parameter() const override {
+    return this->projection_param_;
+  }
 
   //! Map laplacian element matrix to cell (used in poisson equation LHS)
   bool map_laplacian_to_cell() override;

--- a/include/particles/particle_fluid.h
+++ b/include/particles/particle_fluid.h
@@ -41,6 +41,17 @@ class FluidParticle : public mpm::Particle<Tdim> {
   //! Map internal force
   inline void map_internal_force() noexcept override;
 
+  //! Serialize
+  //! \retval buffer Serialized buffer data
+  std::vector<uint8_t> serialize() override;
+
+  //! Deserialize
+  //! \param[in] buffer Serialized buffer data
+  //! \param[in] material Particle material pointers
+  void deserialize(
+      const std::vector<uint8_t>& buffer,
+      std::vector<std::shared_ptr<mpm::Material<Tdim>>>& materials) override;
+
   //! ----------------------------------------------------------------
   //! Semi-Implicit integration functions based on Chorin's Projection
   //! ----------------------------------------------------------------
@@ -50,6 +61,9 @@ class FluidParticle : public mpm::Particle<Tdim> {
   void assign_projection_parameter(double parameter) override {
     this->projection_param_ = parameter;
   };
+
+  //! Return projection parameter
+  double projection_param() const override { return this->projection_param_; }
 
   //! Map laplacian element matrix to cell (used in poisson equation LHS)
   bool map_laplacian_to_cell() override;
@@ -68,33 +82,62 @@ class FluidParticle : public mpm::Particle<Tdim> {
     return (Tdim == 2) ? "P2DFLUID" : "P3DFLUID";
   }
 
+ protected:
+  //! Compute pack size
+  //! \retval pack size of serialized object
+  int compute_pack_size() const override;
+
  private:
   //! Compute turbulent stress
   virtual Eigen::Matrix<double, 6, 1> compute_turbulent_stress();
 
  private:
+  //! particle id
+  using ParticleBase<Tdim>::id_;
+  //! coordinates
+  using ParticleBase<Tdim>::coordinates_;
+  //! Status
+  using ParticleBase<Tdim>::status_;
   //! Cell
   using ParticleBase<Tdim>::cell_;
+  //! Cell id
+  using ParticleBase<Tdim>::cell_id_;
   //! Nodes
   using ParticleBase<Tdim>::nodes_;
   //! Fluid material
   using ParticleBase<Tdim>::material_;
+  //! Material ids
+  using ParticleBase<Tdim>::material_id_;
   //! State variables
   using ParticleBase<Tdim>::state_variables_;
   //! Shape functions
   using Particle<Tdim>::shapefn_;
   //! dN/dX
   using Particle<Tdim>::dn_dx_;
+  //! Size of particle in natural coordinates
+  using Particle<Tdim>::natural_size_;
+  //! Deformation gradient
+  using Particle<Tdim>::deformation_gradient_;
   //! Fluid strain rate
   using Particle<Tdim>::strain_rate_;
-  //! Effective stress of soil skeleton
+  //! Fluid strain
+  using Particle<Tdim>::strain_;
+  //! Fluid stress
   using Particle<Tdim>::stress_;
   //! Particle mass density
   using Particle<Tdim>::mass_density_;
+  //! Displacement
+  using Particle<Tdim>::displacement_;
+  //! Velocity
+  using Particle<Tdim>::velocity_;
+  //! Acceleration
+  using Particle<Tdim>::acceleration_;
   //! Particle mass density
   using Particle<Tdim>::mass_;
   //! Particle total volume
   using Particle<Tdim>::volume_;
+  //! Size of particle
+  using Particle<Tdim>::pack_size_;
   //! Projection parameter for semi-implicit update
   double projection_param_{0.0};
   //! Pressure constraint

--- a/include/particles/particle_fluid.tcc
+++ b/include/particles/particle_fluid.tcc
@@ -204,3 +204,230 @@ bool mpm::FluidParticle<Tdim>::map_correction_matrix_to_cell() {
   }
   return status;
 }
+
+//! Compute size of serialized particle data
+template <unsigned Tdim>
+int mpm::FluidParticle<Tdim>::compute_pack_size() const {
+  int total_size = mpm::Particle<Tdim>::compute_pack_size();
+  int partial_size;
+#ifdef USE_MPI
+  // projection parameter - beta
+  MPI_Pack_size(1, MPI_DOUBLE, MPI_COMM_WORLD, &partial_size);
+  total_size += partial_size;
+#endif
+  return total_size;
+}
+
+//! Serialize particle data
+template <unsigned Tdim>
+std::vector<uint8_t> mpm::FluidParticle<Tdim>::serialize() {
+  // Compute pack size
+  if (pack_size_ == 0) pack_size_ = compute_pack_size();
+  // Initialize data buffer
+  std::vector<uint8_t> data;
+  data.resize(pack_size_);
+  uint8_t* data_ptr = &data[0];
+  int position = 0;
+
+#ifdef USE_MPI
+  // Type
+  int type = ParticleType.at(this->type());
+  MPI_Pack(&type, 1, MPI_INT, data_ptr, data.size(), &position, MPI_COMM_WORLD);
+
+  // Material id
+  unsigned nmaterials = material_id_.size();
+  MPI_Pack(&nmaterials, 1, MPI_UNSIGNED, data_ptr, data.size(), &position,
+           MPI_COMM_WORLD);
+  MPI_Pack(&material_id_[mpm::ParticlePhase::Solid], 1, MPI_UNSIGNED, data_ptr,
+           data.size(), &position, MPI_COMM_WORLD);
+
+  // ID
+  MPI_Pack(&id_, 1, MPI_UNSIGNED_LONG_LONG, data_ptr, data.size(), &position,
+           MPI_COMM_WORLD);
+  // Mass
+  MPI_Pack(&mass_, 1, MPI_DOUBLE, data_ptr, data.size(), &position,
+           MPI_COMM_WORLD);
+  // Volume
+  MPI_Pack(&volume_, 1, MPI_DOUBLE, data_ptr, data.size(), &position,
+           MPI_COMM_WORLD);
+  // Pressure
+  double pressure =
+      (state_variables_[mpm::ParticlePhase::Solid].find("pressure") !=
+       state_variables_[mpm::ParticlePhase::Solid].end())
+          ? state_variables_[mpm::ParticlePhase::Solid].at("pressure")
+          : 0.;
+  MPI_Pack(&pressure, 1, MPI_DOUBLE, data_ptr, data.size(), &position,
+           MPI_COMM_WORLD);
+
+  // Coordinates
+  MPI_Pack(coordinates_.data(), Tdim, MPI_DOUBLE, data_ptr, data.size(),
+           &position, MPI_COMM_WORLD);
+  // Displacement
+  MPI_Pack(displacement_.data(), Tdim, MPI_DOUBLE, data_ptr, data.size(),
+           &position, MPI_COMM_WORLD);
+  // Natural size
+  MPI_Pack(natural_size_.data(), Tdim, MPI_DOUBLE, data_ptr, data.size(),
+           &position, MPI_COMM_WORLD);
+  // Velocity
+  MPI_Pack(velocity_.data(), Tdim, MPI_DOUBLE, data_ptr, data.size(), &position,
+           MPI_COMM_WORLD);
+  // Acceleration
+  MPI_Pack(acceleration_.data(), Tdim, MPI_DOUBLE, data_ptr, data.size(),
+           &position, MPI_COMM_WORLD);
+  // Stress
+  MPI_Pack(stress_.data(), 6, MPI_DOUBLE, data_ptr, data.size(), &position,
+           MPI_COMM_WORLD);
+  // Strain
+  MPI_Pack(strain_.data(), 6, MPI_DOUBLE, data_ptr, data.size(), &position,
+           MPI_COMM_WORLD);
+  // Deformation Gradient
+  MPI_Pack(deformation_gradient_.data(), 9, MPI_DOUBLE, data_ptr, data.size(),
+           &position, MPI_COMM_WORLD);
+
+  // Cell id
+  MPI_Pack(&cell_id_, 1, MPI_UNSIGNED_LONG_LONG, data_ptr, data.size(),
+           &position, MPI_COMM_WORLD);
+
+  // Status
+  MPI_Pack(&status_, 1, MPI_C_BOOL, data_ptr, data.size(), &position,
+           MPI_COMM_WORLD);
+
+  // nstate variables
+  unsigned nstate_vars = state_variables_[mpm::ParticlePhase::Solid].size();
+  MPI_Pack(&nstate_vars, 1, MPI_UNSIGNED, data_ptr, data.size(), &position,
+           MPI_COMM_WORLD);
+
+  // state variables
+  if (this->material(mpm::ParticlePhase::Solid) != nullptr) {
+    std::vector<double> svars;
+    auto state_variables =
+        (this->material(mpm::ParticlePhase::Solid))->state_variables();
+    for (const auto& state_var : state_variables)
+      svars.emplace_back(
+          state_variables_[mpm::ParticlePhase::Solid].at(state_var));
+
+    // Write state vars
+    MPI_Pack(&svars[0], nstate_vars, MPI_DOUBLE, data_ptr, data.size(),
+             &position, MPI_COMM_WORLD);
+  }
+
+  // Projection parameter
+  MPI_Pack(&projection_param_, 1, MPI_DOUBLE, data_ptr, data.size(), &position,
+           MPI_COMM_WORLD);
+#endif
+  return data;
+}
+
+//! Deserialize particle data
+template <unsigned Tdim>
+void mpm::FluidParticle<Tdim>::deserialize(
+    const std::vector<uint8_t>& data,
+    std::vector<std::shared_ptr<mpm::Material<Tdim>>>& materials) {
+  uint8_t* data_ptr = const_cast<uint8_t*>(&data[0]);
+  int position = 0;
+
+#ifdef USE_MPI
+  // Type
+  int type;
+  MPI_Unpack(data_ptr, data.size(), &position, &type, 1, MPI_INT,
+             MPI_COMM_WORLD);
+  assert(type == ParticleType.at(this->type()));
+  // material id
+  int nmaterials = 0;
+  MPI_Unpack(data_ptr, data.size(), &position, &nmaterials, 1, MPI_UNSIGNED,
+             MPI_COMM_WORLD);
+  MPI_Unpack(data_ptr, data.size(), &position,
+             &material_id_[mpm::ParticlePhase::Solid], 1, MPI_UNSIGNED,
+             MPI_COMM_WORLD);
+
+  assert(nmaterials == materials.size());
+  // ID
+  MPI_Unpack(data_ptr, data.size(), &position, &id_, 1, MPI_UNSIGNED_LONG_LONG,
+             MPI_COMM_WORLD);
+  // mass
+  MPI_Unpack(data_ptr, data.size(), &position, &mass_, 1, MPI_DOUBLE,
+             MPI_COMM_WORLD);
+  // volume
+  MPI_Unpack(data_ptr, data.size(), &position, &volume_, 1, MPI_DOUBLE,
+             MPI_COMM_WORLD);
+  // mass density
+  this->mass_density_ = mass_ / volume_;
+
+  // pressure
+  double pressure;
+  MPI_Unpack(data_ptr, data.size(), &position, &pressure, 1, MPI_DOUBLE,
+             MPI_COMM_WORLD);
+
+  // Coordinates
+  MPI_Unpack(data_ptr, data.size(), &position, coordinates_.data(), Tdim,
+             MPI_DOUBLE, MPI_COMM_WORLD);
+  // Displacement
+  MPI_Unpack(data_ptr, data.size(), &position, displacement_.data(), Tdim,
+             MPI_DOUBLE, MPI_COMM_WORLD);
+  // Natural size
+  MPI_Unpack(data_ptr, data.size(), &position, natural_size_.data(), Tdim,
+             MPI_DOUBLE, MPI_COMM_WORLD);
+  // Velocity
+  MPI_Unpack(data_ptr, data.size(), &position, velocity_.data(), Tdim,
+             MPI_DOUBLE, MPI_COMM_WORLD);
+  // Acceleration
+  MPI_Unpack(data_ptr, data.size(), &position, acceleration_.data(), Tdim,
+             MPI_DOUBLE, MPI_COMM_WORLD);
+  // Stress
+  MPI_Unpack(data_ptr, data.size(), &position, stress_.data(), 6, MPI_DOUBLE,
+             MPI_COMM_WORLD);
+  this->previous_stress_ = stress_;
+  // Strain
+  MPI_Unpack(data_ptr, data.size(), &position, strain_.data(), 6, MPI_DOUBLE,
+             MPI_COMM_WORLD);
+  // Deformation gradient
+  MPI_Unpack(data_ptr, data.size(), &position, deformation_gradient_.data(), 9,
+             MPI_DOUBLE, MPI_COMM_WORLD);
+
+  // cell id
+  MPI_Unpack(data_ptr, data.size(), &position, &cell_id_, 1,
+             MPI_UNSIGNED_LONG_LONG, MPI_COMM_WORLD);
+  // status
+  MPI_Unpack(data_ptr, data.size(), &position, &status_, 1, MPI_C_BOOL,
+             MPI_COMM_WORLD);
+
+  // Assign materials
+  assert(material_id_[mpm::ParticlePhase::Solid] ==
+         materials.at(mpm::ParticlePhase::Solid)->id());
+  bool assign_mat =
+      this->assign_material(materials.at(mpm::ParticlePhase::Solid));
+  if (!assign_mat)
+    throw std::runtime_error(
+        "deserialize particle(): Material assignment failed");
+
+  // nstate vars
+  unsigned nstate_vars;
+  MPI_Unpack(data_ptr, data.size(), &position, &nstate_vars, 1, MPI_UNSIGNED,
+             MPI_COMM_WORLD);
+
+  if (nstate_vars > 0) {
+    std::vector<double> svars;
+    svars.reserve(nstate_vars);
+    MPI_Unpack(data_ptr, data.size(), &position, &svars[0], nstate_vars,
+               MPI_DOUBLE, MPI_COMM_WORLD);
+
+    // Reinitialize state variables
+    auto mat_state_vars = (this->material())->initialise_state_variables();
+    if (mat_state_vars.size() != nstate_vars)
+      throw std::runtime_error(
+          "Deserialize particle(): state_vars size mismatch");
+    unsigned i = 0;
+    auto state_variables = (this->material())->state_variables();
+    for (const auto& state_var : state_variables) {
+      this->state_variables_[mpm::ParticlePhase::Solid].at(state_var) =
+          svars[i];
+      ++i;
+    }
+  }
+
+  // projection parameter
+  MPI_Unpack(data_ptr, data.size(), &position, &projection_param_, 1,
+             MPI_DOUBLE, MPI_COMM_WORLD);
+
+#endif
+}

--- a/include/particles/particle_twophase.h
+++ b/include/particles/particle_twophase.h
@@ -176,7 +176,9 @@ class TwoPhaseParticle : public mpm::Particle<Tdim> {
   };
 
   //! Return projection parameter
-  double projection_parameter() const override { return this->projection_param_; }
+  double projection_parameter() const override {
+    return this->projection_param_;
+  }
 
   //! Map drag matrix to cell assuming linear-darcy drag force
   bool map_drag_matrix_to_cell() override;

--- a/include/particles/particle_twophase.h
+++ b/include/particles/particle_twophase.h
@@ -176,7 +176,7 @@ class TwoPhaseParticle : public mpm::Particle<Tdim> {
   };
 
   //! Return projection parameter
-  double projection_param() const override { return this->projection_param_; }
+  double projection_parameter() const override { return this->projection_param_; }
 
   //! Map drag matrix to cell assuming linear-darcy drag force
   bool map_drag_matrix_to_cell() override;

--- a/include/particles/particle_twophase.h
+++ b/include/particles/particle_twophase.h
@@ -175,6 +175,9 @@ class TwoPhaseParticle : public mpm::Particle<Tdim> {
     this->projection_param_ = parameter;
   };
 
+  //! Return projection parameter
+  double projection_param() const override { return this->projection_param_; }
+
   //! Map drag matrix to cell assuming linear-darcy drag force
   bool map_drag_matrix_to_cell() override;
 
@@ -285,7 +288,7 @@ class TwoPhaseParticle : public mpm::Particle<Tdim> {
   using Particle<Tdim>::particle_velocity_constraints_;
   //! Size of particle
   using Particle<Tdim>::pack_size_;
-  //! Size of particle
+  //! Deformation gradient
   using Particle<Tdim>::deformation_gradient_;
 
   //! Liquid mass

--- a/include/particles/particle_twophase.tcc
+++ b/include/particles/particle_twophase.tcc
@@ -974,6 +974,10 @@ int mpm::TwoPhaseParticle<Tdim>::compute_pack_size() const {
   MPI_Pack_size(1, MPI_UNSIGNED, MPI_COMM_WORLD, &partial_size);
   total_size += partial_size;
 
+  // projection parameter - beta
+  MPI_Pack_size(1, MPI_DOUBLE, MPI_COMM_WORLD, &partial_size);
+  total_size += partial_size;
+
   // liquid mass
   MPI_Pack_size(1, MPI_DOUBLE, MPI_COMM_WORLD, &partial_size);
   total_size += partial_size;
@@ -1097,6 +1101,9 @@ std::vector<uint8_t> mpm::TwoPhaseParticle<Tdim>::serialize() {
   }
 
   // Liquid Phase
+  // Projection parameter
+  MPI_Pack(&projection_param_, 1, MPI_DOUBLE, data_ptr, data.size(), &position,
+           MPI_COMM_WORLD);
   // Mass
   MPI_Pack(&liquid_mass_, 1, MPI_DOUBLE, data_ptr, data.size(), &position,
            MPI_COMM_WORLD);
@@ -1250,6 +1257,9 @@ void mpm::TwoPhaseParticle<Tdim>::deserialize(
   }
 
   // Liquid Phase
+  // projection parameter
+  MPI_Unpack(data_ptr, data.size(), &position, &projection_param_, 1,
+             MPI_DOUBLE, MPI_COMM_WORLD);
   // liquid mass
   MPI_Unpack(data_ptr, data.size(), &position, &liquid_mass_, 1, MPI_DOUBLE,
              MPI_COMM_WORLD);

--- a/include/solvers/mpm_semi_implicit_twophase.tcc
+++ b/include/solvers/mpm_semi_implicit_twophase.tcc
@@ -280,6 +280,48 @@ bool mpm::MPMSemiImplicitTwoPhase<Tdim>::solve() {
       }
     }  // Wait for tasks to finish
 
+#ifdef USE_MPI
+    // Run if there is more than a single MPI task
+    if (mpi_size > 1) {
+      // MPI all reduce external force of mixture
+      mesh_->template nodal_halo_exchange<Eigen::Matrix<double, Tdim, 1>, Tdim>(
+          std::bind(&mpm::NodeBase<Tdim>::external_force, std::placeholders::_1,
+                    mpm::NodePhase::NMixture),
+          std::bind(&mpm::NodeBase<Tdim>::update_external_force,
+                    std::placeholders::_1, false, mpm::NodePhase::NMixture,
+                    std::placeholders::_2));
+      // MPI all reduce external force of pore fluid
+      mesh_->template nodal_halo_exchange<Eigen::Matrix<double, Tdim, 1>, Tdim>(
+          std::bind(&mpm::NodeBase<Tdim>::external_force, std::placeholders::_1,
+                    mpm::NodePhase::NLiquid),
+          std::bind(&mpm::NodeBase<Tdim>::update_external_force,
+                    std::placeholders::_1, false, mpm::NodePhase::NLiquid,
+                    std::placeholders::_2));
+
+      // MPI all reduce internal force of mixture
+      mesh_->template nodal_halo_exchange<Eigen::Matrix<double, Tdim, 1>, Tdim>(
+          std::bind(&mpm::NodeBase<Tdim>::internal_force, std::placeholders::_1,
+                    mpm::NodePhase::NMixture),
+          std::bind(&mpm::NodeBase<Tdim>::update_internal_force,
+                    std::placeholders::_1, false, mpm::NodePhase::NMixture,
+                    std::placeholders::_2));
+      // MPI all reduce internal force of pore liquid
+      mesh_->template nodal_halo_exchange<Eigen::Matrix<double, Tdim, 1>, Tdim>(
+          std::bind(&mpm::NodeBase<Tdim>::internal_force, std::placeholders::_1,
+                    mpm::NodePhase::NLiquid),
+          std::bind(&mpm::NodeBase<Tdim>::update_internal_force,
+                    std::placeholders::_1, false, mpm::NodePhase::NLiquid,
+                    std::placeholders::_2));
+
+      // MPI all reduce drag force
+      mesh_->template nodal_halo_exchange<Eigen::Matrix<double, Tdim, 1>, Tdim>(
+          std::bind(&mpm::NodeBase<Tdim>::drag_force_coefficient,
+                    std::placeholders::_1),
+          std::bind(&mpm::NodeBase<Tdim>::update_drag_force_coefficient,
+                    std::placeholders::_1, false, std::placeholders::_2));
+    }
+#endif
+
     // Reinitialise system matrices to solve predictor equation and PPE
     bool matrix_reinitialization_status = this->reinitialise_matrix();
     if (!matrix_reinitialization_status) {

--- a/tests/particles/particle_serialize_deserialize_fluid_test.cc
+++ b/tests/particles/particle_serialize_deserialize_fluid_test.cc
@@ -150,7 +150,7 @@ TEST_CASE("Fluid particle is checked for serialization and deserialization",
     // Check particle status
     REQUIRE(particle->status() == rparticle->status());
     // Check particle projection parameter
-    REQUIRE(particle->projection_param() == rparticle->projection_param());
+    REQUIRE(particle->projection_parameter() == rparticle->projection_parameter());
 
     // Check for coordinates
     auto coordinates = rparticle->coordinates();

--- a/tests/particles/particle_serialize_deserialize_fluid_test.cc
+++ b/tests/particles/particle_serialize_deserialize_fluid_test.cc
@@ -150,7 +150,8 @@ TEST_CASE("Fluid particle is checked for serialization and deserialization",
     // Check particle status
     REQUIRE(particle->status() == rparticle->status());
     // Check particle projection parameter
-    REQUIRE(particle->projection_parameter() == rparticle->projection_parameter());
+    REQUIRE(particle->projection_parameter() ==
+            rparticle->projection_parameter());
 
     // Check for coordinates
     auto coordinates = rparticle->coordinates();

--- a/tests/particles/particle_serialize_deserialize_fluid_test.cc
+++ b/tests/particles/particle_serialize_deserialize_fluid_test.cc
@@ -11,7 +11,7 @@
 #include "pod_particle.h"
 
 //! \brief Check particle class for serialization and deserialization
-TEST_CASE("Particle is checked for serialization and deserialization",
+TEST_CASE("Fluid particle is checked for serialization and deserialization",
           "[particle][3D][serialize][fluid]") {
   // Dimension
   const unsigned Dim = 3;

--- a/tests/particles/particle_serialize_deserialize_fluid_test.cc
+++ b/tests/particles/particle_serialize_deserialize_fluid_test.cc
@@ -1,3 +1,4 @@
+#include <chrono>
 #include <limits>
 
 #include "catch.hpp"
@@ -6,18 +7,18 @@
 #include "logger.h"
 #include "material.h"
 #include "particle.h"
-#include "particle_twophase.h"
-#include "pod_particle_twophase.h"
+#include "particle_fluid.h"
+#include "pod_particle.h"
 
 //! \brief Check particle class for serialization and deserialization
-TEST_CASE("Twophase particle is checked for serialization and deserialization",
-          "[particle][3D][serialize][2Phase]") {
+TEST_CASE("Particle is checked for serialization and deserialization",
+          "[particle][3D][serialize][fluid]") {
   // Dimension
   const unsigned Dim = 3;
 
   // Logger
   std::unique_ptr<spdlog::logger> console_ = std::make_unique<spdlog::logger>(
-      "particle_serialize_deserialize_twophase_test", mpm::stdout_sink);
+      "particle_serialize_deserialize_fluid_test", mpm::stdout_sink);
 
   // Check initialise particle from POD file
   SECTION("Check initialise particle POD") {
@@ -28,37 +29,23 @@ TEST_CASE("Twophase particle is checked for serialization and deserialization",
     pcoords.setZero();
 
     std::shared_ptr<mpm::ParticleBase<Dim>> particle =
-        std::make_shared<mpm::TwoPhaseParticle<Dim>>(id, pcoords);
+        std::make_shared<mpm::FluidParticle<Dim>>(id, pcoords);
 
-    // Assign material
-    unsigned solid_mid = 1;
-    unsigned liquid_mid = 2;
     // Initialise material
-    Json jsolid_material;
-    Json jliquid_material;
-    jsolid_material["density"] = 1000.;
-    jsolid_material["youngs_modulus"] = 1.0E+7;
-    jsolid_material["poisson_ratio"] = 0.3;
-    jsolid_material["porosity"] = 0.3;
-    jsolid_material["k_x"] = 0.001;
-    jsolid_material["k_y"] = 0.001;
-    jsolid_material["k_z"] = 0.001;
-    jsolid_material["intrinsic_permeability"] = true;
-    jliquid_material["density"] = 1000.;
-    jliquid_material["bulk_modulus"] = 2.0E9;
-    jliquid_material["dynamic_viscosity"] = 8.90E-4;
+    Json jmaterial;
+    jmaterial["density"] = 1000.;
+    jmaterial["bulk_modulus"] = 2.E9;
+    jmaterial["dynamic_viscosity"] = 8.9E-4;
+    jmaterial["incompressible"] = true;
+    unsigned mid = 1;
 
-    auto solid_material =
+    auto material =
         Factory<mpm::Material<Dim>, unsigned, const Json&>::instance()->create(
-            "LinearElastic3D", std::move(solid_mid), jsolid_material);
-    auto liquid_material =
-        Factory<mpm::Material<Dim>, unsigned, const Json&>::instance()->create(
-            "Newtonian3D", std::move(liquid_mid), jliquid_material);
+            "Newtonian3D", std::move(mid), jmaterial);
     std::vector<std::shared_ptr<mpm::Material<Dim>>> materials;
-    materials.emplace_back(solid_material);
-    materials.emplace_back(liquid_material);
+    materials.emplace_back(material);
 
-    mpm::PODParticleTwoPhase h5_particle;
+    mpm::PODParticle h5_particle;
     h5_particle.id = 13;
     h5_particle.mass = 501.5;
 
@@ -110,8 +97,8 @@ TEST_CASE("Twophase particle is checked for serialization and deserialization",
     h5_particle.gamma_yz = strain[4];
     h5_particle.gamma_xz = strain[5];
 
-    Eigen::Matrix<double, 3, 3> deformation_gradient;
-    deformation_gradient << 1.0, -2.0, 3.0, -4.0, 5.0, -6.0, -7.0, 8.0, -9.0;
+    Eigen::Matrix<double, 3, 3> deformation_gradient =
+        Eigen::Matrix<double, 3, 3>::Identity();
     h5_particle.defgrad_00 = deformation_gradient(0, 0);
     h5_particle.defgrad_01 = deformation_gradient(0, 1);
     h5_particle.defgrad_02 = deformation_gradient(0, 2);
@@ -130,35 +117,15 @@ TEST_CASE("Twophase particle is checked for serialization and deserialization",
 
     h5_particle.material_id = 1;
 
-    h5_particle.nstate_vars = 0;
+    h5_particle.nstate_vars = 1;
 
-    for (unsigned i = 0; i < h5_particle.nstate_vars; ++i)
-      h5_particle.svars[i] = 0.;
+    h5_particle.svars[0] = 1000.0;
 
-    h5_particle.liquid_mass = 100.1;
-
-    Eigen::Vector3d liquid_velocity;
-    liquid_velocity << 5.5, 2.1, 4.2;
-    h5_particle.liquid_velocity_x = liquid_velocity[0];
-    h5_particle.liquid_velocity_y = liquid_velocity[1];
-    h5_particle.liquid_velocity_z = liquid_velocity[2];
-
-    h5_particle.porosity = 0.33;
-
-    h5_particle.liquid_saturation = 1.;
-
-    h5_particle.liquid_material_id = 2;
-
-    h5_particle.nliquid_state_vars = 1;
-
-    for (unsigned i = 0; i < h5_particle.nliquid_state_vars; ++i)
-      h5_particle.liquid_svars[i] = 0.;
-
-    // Reinitialise particle from POD data
+    // Reinitialise particle from HDF5 data
     REQUIRE(particle->initialise_particle(h5_particle, materials) == true);
 
     // Assign projection parameter
-    particle->assign_projection_parameter(0.0);
+    particle->assign_projection_parameter(1.0);
 
     // Serialize particle
     auto buffer = particle->serialize();
@@ -166,7 +133,7 @@ TEST_CASE("Twophase particle is checked for serialization and deserialization",
 
     // Deserialize particle
     std::shared_ptr<mpm::ParticleBase<Dim>> rparticle =
-        std::make_shared<mpm::TwoPhaseParticle<Dim>>(id, pcoords);
+        std::make_shared<mpm::FluidParticle<Dim>>(id, pcoords);
 
     REQUIRE_NOTHROW(rparticle->deserialize(buffer, materials));
 
@@ -178,6 +145,8 @@ TEST_CASE("Twophase particle is checked for serialization and deserialization",
     REQUIRE(particle->volume() == rparticle->volume());
     // Check particle mass density
     REQUIRE(particle->mass_density() == rparticle->mass_density());
+    // Check particle pressure
+    REQUIRE(particle->pressure() == rparticle->pressure());
     // Check particle status
     REQUIRE(particle->status() == rparticle->status());
     // Check particle projection parameter
@@ -240,32 +209,15 @@ TEST_CASE("Twophase particle is checked for serialization and deserialization",
     // Check material id
     REQUIRE(particle->material_id() == rparticle->material_id());
 
-    // Check liquid mass
-    REQUIRE(particle->liquid_mass() == rparticle->liquid_mass());
-
-    // Check liquid velocity
-    auto pliquid_velocity = rparticle->liquid_velocity();
-    REQUIRE(pliquid_velocity.size() == Dim);
-    for (unsigned i = 0; i < Dim; ++i)
-      REQUIRE(pliquid_velocity(i) ==
-              Approx(liquid_velocity(i)).epsilon(Tolerance));
-
-    // Check porosity
-    REQUIRE(particle->porosity() == rparticle->porosity());
-
-    // Check liquid material id
-    REQUIRE(particle->material_id(mpm::ParticlePhase::Liquid) ==
-            rparticle->material_id(mpm::ParticlePhase::Liquid));
+    // Check state variable size
+    REQUIRE(particle->state_variables().size() ==
+            rparticle->state_variables().size());
 
     // Check state variables
-    for (unsigned phase = 0; phase < materials.size(); phase++) {
-      REQUIRE(particle->state_variables(phase).size() ==
-              rparticle->state_variables(phase).size());
-      auto state_variables = materials[phase]->state_variables();
-      for (const auto& state_var : state_variables) {
-        REQUIRE(particle->state_variable(state_var, phase) ==
-                rparticle->state_variable(state_var, phase));
-      }
+    auto state_variables = material->state_variables();
+    for (const auto& state_var : state_variables) {
+      REQUIRE(particle->state_variable(state_var) ==
+              rparticle->state_variable(state_var));
     }
 
     SECTION("Performance benchmarks") {
@@ -279,7 +231,7 @@ TEST_CASE("Twophase particle is checked for serialization and deserialization",
         auto buffer = particle->serialize();
         // Deserialize particle
         std::shared_ptr<mpm::ParticleBase<Dim>> rparticle =
-            std::make_shared<mpm::TwoPhaseParticle<Dim>>(id, pcoords);
+            std::make_shared<mpm::FluidParticle<Dim>>(id, pcoords);
 
         REQUIRE_NOTHROW(rparticle->deserialize(buffer, materials));
       }

--- a/tests/particles/particle_serialize_deserialize_twophase_test.cc
+++ b/tests/particles/particle_serialize_deserialize_twophase_test.cc
@@ -181,7 +181,8 @@ TEST_CASE("Twophase particle is checked for serialization and deserialization",
     // Check particle status
     REQUIRE(particle->status() == rparticle->status());
     // Check particle projection parameter
-    REQUIRE(particle->projection_parameter() == rparticle->projection_parameter());
+    REQUIRE(particle->projection_parameter() ==
+            rparticle->projection_parameter());
 
     // Check for coordinates
     auto coordinates = rparticle->coordinates();

--- a/tests/particles/particle_serialize_deserialize_twophase_test.cc
+++ b/tests/particles/particle_serialize_deserialize_twophase_test.cc
@@ -181,7 +181,7 @@ TEST_CASE("Twophase particle is checked for serialization and deserialization",
     // Check particle status
     REQUIRE(particle->status() == rparticle->status());
     // Check particle projection parameter
-    REQUIRE(particle->projection_param() == rparticle->projection_param());
+    REQUIRE(particle->projection_parameter() == rparticle->projection_parameter());
 
     // Check for coordinates
     auto coordinates = rparticle->coordinates();

--- a/tests/particles/particle_test.cc
+++ b/tests/particles/particle_test.cc
@@ -3362,6 +3362,7 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     // Specific functions for TwoPhaseParticle.
     // Expecting throws if called from Particle.
     REQUIRE_THROWS(particle->assign_projection_parameter(1));
+    REQUIRE_THROWS(particle->projection_parameter());
     REQUIRE_THROWS(particle->map_laplacian_to_cell());
     REQUIRE_THROWS(particle->map_poisson_right_to_cell());
     REQUIRE_THROWS(particle->map_correction_matrix_to_cell());


### PR DESCRIPTION
**Describe the PR**
This PR provides a remedy to fix problems observed in #68. 
1. This PR reverts back PR #6 which introduces kinematic field errors.
2. This PR also introduces serializing and deserializing of projection parameter which was not transferred before. Similar mitigation has been added to fluid particles as it will cause future issues if it is not treated as well.

**Related Issues/PRs**
Issues #68

**Additional context**
1. Related issues should occur as well in the fluid-particle run by the Navier-stokes solver. Thus, additional actions are made to provide future problems.
2. Some tests have been added to further improve coverages.