### PR TITLE
[Compile] SIGSTKSZ fix and add arm64 support

### DIFF
--- a/external/catch.hpp
+++ b/external/catch.hpp
@@ -2141,7 +2141,11 @@ namespace Catch{
                 __asm__("li r0, 20\nsc\nnop\nli r0, 37\nli r4, 2\nsc\nnop\n" \
                 : : : "memory","r0","r3","r4" ) /* NOLINT */
     #else
-        #define CATCH_TRAP() __asm__("int $3\n" : : /* NOLINT */ )
+        #if defined(__i386__) || defined(__x86_64__)
+            #define CATCH_TRAP() __asm__("int $3\n" : : ) /* NOLINT */
+        #elif defined(__aarch64__)
+            #define CATCH_TRAP()  __asm__(".inst 0xd4200000")
+        #endif
     #endif
 
 #elif defined(CATCH_PLATFORM_LINUX)


### PR DESCRIPTION
**Describe the PR**
This PR adds the following modification to `catch.hpp`:
1. Fix https://github.com/geomechanics/mpm/issues/61 since `SIGSTKSZ` is not a constant anymore in libc6 2.34.
2. Add arm64 support to `catch.hpp`.

**Related Issues/PRs**
Issue https://github.com/geomechanics/mpm/issues/61

**Additional context**
This PR enhances the possibility to compile in Linux Ubuntu 22.04 and MacBook M1 arm64 chips. 
