### PR TITLE
[Bugfix] Free surface detection for nonlocal elements

### DIFF
--- a/include/cells/cell.h
+++ b/include/cells/cell.h
@@ -435,6 +435,14 @@ class Cell {
   bool initialiase_nonlocal(
       const tsl::robin_map<std::string, double>& nonlocal_properties);
 
+  //! Return nodes id in a cell
+  //! \ingroup Nonlocal
+  std::set<mpm::Index> local_nodes_id() const;
+
+  //! Return number of local shape functions, returns zero if the element type
+  //! is not set.
+  //! \ingroup Nonlocal
+  unsigned nfunctions_local() const;
   /**@}*/
 
  private:

--- a/include/cells/cell.tcc
+++ b/include/cells/cell.tcc
@@ -995,3 +995,19 @@ bool mpm::Cell<Tdim>::initialiase_nonlocal(
   }
   return status;
 }
+
+//! Return nodes id in a cell
+template <unsigned Tdim>
+std::set<mpm::Index> mpm::Cell<Tdim>::local_nodes_id() const {
+  std::set<mpm::Index> nodes_id_lists;
+  for (unsigned i = 0; i < this->nfunctions_local(); i++)
+    nodes_id_lists.insert(nodes_[i]->id());
+  return nodes_id_lists;
+}
+
+//! Return number of local shape functions, returns zero if the element type
+//! is not set.
+template <unsigned Tdim>
+unsigned mpm::Cell<Tdim>::nfunctions_local() const {
+  return (this->element_ != nullptr ? this->element_->nfunctions_local() : 0);
+};

--- a/include/elements/2d/quadrilateral_bspline_element.h
+++ b/include/elements/2d/quadrilateral_bspline_element.h
@@ -169,6 +169,9 @@ class QuadrilateralBSplineElement : public QuadrilateralElement<2, 4> {
   //! Return number of shape functions
   unsigned nfunctions() const override { return nconnectivity_; }
 
+  //! Return number of local shape functions
+  unsigned nfunctions_local() const override { return 4; }
+
   //! Return if natural coordinates can be evaluates
   bool isvalid_natural_coordinates_analytical() const override { return false; }
 

--- a/include/elements/2d/quadrilateral_element.h
+++ b/include/elements/2d/quadrilateral_element.h
@@ -90,6 +90,9 @@ class QuadrilateralElement : public Element<Tdim> {
   //! Return number of shape functions
   unsigned nfunctions() const override { return Tnfunctions; }
 
+  //! Return number of local shape functions
+  unsigned nfunctions_local() const override { return Tnfunctions; }
+
   //! Evaluate shape functions at given local coordinates
   //! \param[in] xi given local coordinates
   //! \param[in] particle_size Particle size

--- a/include/elements/2d/quadrilateral_gimp_element.h
+++ b/include/elements/2d/quadrilateral_gimp_element.h
@@ -122,6 +122,9 @@ class QuadrilateralGIMPElement : public QuadrilateralElement<2, 4> {
   //! Return number of shape functions
   unsigned nfunctions() const override { return Tnfunctions; }
 
+  //! Return number of local shape functions
+  unsigned nfunctions_local() const override { return 4; }
+
   //! Return if natural coordinates can be evaluates
   bool isvalid_natural_coordinates_analytical() const override { return false; }
 

--- a/include/elements/2d/quadrilateral_lme_element.h
+++ b/include/elements/2d/quadrilateral_lme_element.h
@@ -176,6 +176,9 @@ class QuadrilateralLMEElement : public QuadrilateralElement<2, 4> {
   //! Return number of shape functions
   unsigned nfunctions() const override { return nconnectivity_; }
 
+  //! Return number of local shape functions
+  unsigned nfunctions_local() const override { return 4; }
+
   //! Return if natural coordinates can be evaluates
   bool isvalid_natural_coordinates_analytical() const override { return false; }
 

--- a/include/elements/2d/triangle_element.h
+++ b/include/elements/2d/triangle_element.h
@@ -60,6 +60,9 @@ class TriangleElement : public Element<Tdim> {
   //! Return number of shape functions
   unsigned nfunctions() const override { return Tnfunctions; }
 
+  //! Return number of local shape functions
+  unsigned nfunctions_local() const override { return Tnfunctions; }
+
   //! Evaluate shape functions at given local coordinates
   //! \param[in] xi given local coordinates
   //! \param[in] particle_size Particle size

--- a/include/elements/2d/triangle_lme_element.h
+++ b/include/elements/2d/triangle_lme_element.h
@@ -138,6 +138,9 @@ class TriangleLMEElement : public TriangleElement<2, 3> {
   //! Return number of shape functions
   unsigned nfunctions() const override { return nconnectivity_; }
 
+  //! Return number of local shape functions
+  unsigned nfunctions_local() const override { return 3; }
+
   //! Return if natural coordinates can be evaluates
   bool isvalid_natural_coordinates_analytical() const override { return false; }
 

--- a/include/elements/3d/hexahedron_bspline_element.h
+++ b/include/elements/3d/hexahedron_bspline_element.h
@@ -118,6 +118,9 @@ class HexahedronBSplineElement : public HexahedronElement<3, 8> {
   //! Return number of shape functions
   unsigned nfunctions() const override { return nconnectivity_; }
 
+  //! Return number of local shape functions
+  unsigned nfunctions_local() const override { return 8; }
+
   //! Assign nodal connectivity property for bspline elements
   //! \param[in] nodal_coordinates Coordinates of nodes forming the cell
   //! \param[in] nodal_properties Vector determining node type for each

--- a/include/elements/3d/hexahedron_element.h
+++ b/include/elements/3d/hexahedron_element.h
@@ -126,6 +126,9 @@ class HexahedronElement : public Element<Tdim> {
   //! Return number of functions
   unsigned nfunctions() const override { return Tnfunctions; }
 
+  //! Return number of local shape functions
+  unsigned nfunctions_local() const override { return Tnfunctions; }
+
   //! Evaluate shape functions at given local coordinates
   //! \param[in] xi given local coordinates
   //! \param[in] particle_size Particle size

--- a/include/elements/3d/hexahedron_gimp_element.h
+++ b/include/elements/3d/hexahedron_gimp_element.h
@@ -101,6 +101,9 @@ class HexahedronGIMPElement : public HexahedronElement<3, 8> {
   //! Return number of shape functions
   unsigned nfunctions() const override { return Tnfunctions; }
 
+  //! Return number of local shape functions
+  unsigned nfunctions_local() const override { return 8; }
+
  private:
   //! Return natural nodal coordinates
   Eigen::MatrixXd natural_nodal_coordinates() const;

--- a/include/elements/3d/hexahedron_lme_element.h
+++ b/include/elements/3d/hexahedron_lme_element.h
@@ -108,6 +108,9 @@ class HexahedronLMEElement : public HexahedronElement<3, 8> {
   //! Return number of shape functions
   unsigned nfunctions() const override { return nconnectivity_; }
 
+  //! Return number of local shape functions
+  unsigned nfunctions_local() const override { return 8; }
+
   //! Assign nodal connectivity property for LME elements
   //! \param[in] beta Coldness function of the system in the range of [0,inf)
   //! \param[in] radius Support radius of the kernel

--- a/include/elements/3d/tetrahedron_element.h
+++ b/include/elements/3d/tetrahedron_element.h
@@ -49,6 +49,9 @@ class TetrahedronElement : public Element<Tdim> {
   //! Return number of functions
   unsigned nfunctions() const override { return Tnfunctions; }
 
+  //! Return number of local shape functions
+  unsigned nfunctions_local() const override { return Tnfunctions; }
+
   //! Evaluate shape functions at given local coordinates
   //! \param[in] xi given local coordinates
   //! \param[in] particle_size Particle size

--- a/include/elements/element.h
+++ b/include/elements/element.h
@@ -48,6 +48,9 @@ class Element {
   //! Return number of shape functions
   virtual unsigned nfunctions() const = 0;
 
+  //! Return number of local shape functions
+  virtual unsigned nfunctions_local() const = 0;
+
   //! Evaluate shape functions at given local coordinates
   //! \param[in] xi given local coordinates
   //! \param[in] particle_size Particle size

--- a/include/mesh/mesh_multiphase.tcc
+++ b/include/mesh/mesh_multiphase.tcc
@@ -55,7 +55,7 @@ bool mpm::Mesh<Tdim>::compute_free_surface_by_geometry(
       const auto& node_id = (*citr)->nodes_id();
       if ((*citr)->volume_fraction() < volume_tolerance) {
         candidate_cell = true;
-        for (const auto id : node_id) {
+        for (const auto id : (*citr)->local_nodes_id()) {
           map_nodes_[id]->assign_free_surface(true);
         }
       } else {
@@ -63,7 +63,8 @@ bool mpm::Mesh<Tdim>::compute_free_surface_by_geometry(
         for (const auto neighbour_cell_id : (*citr)->neighbours()) {
           if (!map_cells_[neighbour_cell_id]->status()) {
             candidate_cell = true;
-            const auto& n_node_id = map_cells_[neighbour_cell_id]->nodes_id();
+            const auto& n_node_id =
+                map_cells_[neighbour_cell_id]->local_nodes_id();
 
             // Detect common node id
             std::set<mpm::Index> common_node_id;
@@ -191,7 +192,6 @@ bool mpm::Mesh<Tdim>::compute_free_surface_by_geometry(
     // If secondary check is needed
     if (secondary_check) {
       // Construct scanning region
-      // TODO: spacing distance should be a function of porosity
       const double spacing_distance = smoothing_length;
       VectorDim t_coord = p_coord + spacing_distance * normal;
 
@@ -337,7 +337,7 @@ bool mpm::Mesh<Tdim>::compute_free_surface_by_density(double volume_tolerance) {
       if (!internal) {
         if ((*citr)->volume_fraction() < volume_tolerance) {
           cell_at_interface = true;
-          for (const auto id : node_id) {
+          for (const auto id : (*citr)->local_nodes_id()) {
             map_nodes_[id]->assign_free_surface(cell_at_interface);
           }
         } else {
@@ -345,7 +345,8 @@ bool mpm::Mesh<Tdim>::compute_free_surface_by_density(double volume_tolerance) {
             if (map_cells_[neighbour_cell_id]->volume_fraction() <
                 volume_tolerance) {
               cell_at_interface = true;
-              const auto& n_node_id = map_cells_[neighbour_cell_id]->nodes_id();
+              const auto& n_node_id =
+                  map_cells_[neighbour_cell_id]->local_nodes_id();
 
               // Detect common node id
               std::set<mpm::Index> common_node_id;

--- a/tests/cells/cell_test.cc
+++ b/tests/cells/cell_test.cc
@@ -735,6 +735,10 @@ TEST_CASE("Cell is checked for 2D case", "[cell][2D]") {
     REQUIRE(cell->upgrade_status(4) == false);
     REQUIRE(cell->initialiase_nonlocal(nonlocal_properties) == false);
     REQUIRE_THROWS(cell->assign_nonlocal_elementptr(bspline_element));
+    REQUIRE(cell->nfunctions_local() == 4);
+
+    const auto& local_node_id = cell->local_nodes_id();
+    REQUIRE(local_node_id.size() == 4);
 
     // nonlocal functions - test successful bspline
     // BSPLINE
@@ -764,6 +768,10 @@ TEST_CASE("Cell is checked for 2D case", "[cell][2D]") {
     REQUIRE(bspline_cell->nnodes() == 16);
 
     REQUIRE(bspline_cell->initialiase_nonlocal(nonlocal_properties) == true);
+    REQUIRE(bspline_cell->nfunctions_local() == 4);
+
+    const auto& bspline_local_node_id = bspline_cell->local_nodes_id();
+    REQUIRE(bspline_local_node_id.size() == 4);
 
     // LME
     auto lme_cell =
@@ -799,6 +807,10 @@ TEST_CASE("Cell is checked for 2D case", "[cell][2D]") {
     nonlocal_properties.insert(
         std::pair<std::string, double>("support_radius", r));
     REQUIRE(lme_cell->initialiase_nonlocal(nonlocal_properties) == true);
+    REQUIRE(lme_cell->nfunctions_local() == 4);
+
+    const auto& lme_local_node_id = lme_cell->local_nodes_id();
+    REQUIRE(lme_local_node_id.size() == 4);
   }
 }
 

--- a/tests/elements/hexahedron_bspline_element_test.cc
+++ b/tests/elements/hexahedron_bspline_element_test.cc
@@ -34,6 +34,8 @@ TEST_CASE("Hexahedron bspline elements are checked",
 
       // Check shape function
       REQUIRE(shapefn.size() == 8);
+      REQUIRE(hex->nfunctions() == 8);
+      REQUIRE(hex->nfunctions_local() == 8);
 
       REQUIRE(shapefn(0) == Approx(0.125).epsilon(Tolerance));
       REQUIRE(shapefn(1) == Approx(0.125).epsilon(Tolerance));
@@ -223,6 +225,8 @@ TEST_CASE("Hexahedron bspline elements are checked",
 
           // Check shape function
           REQUIRE(shapefn.size() == 64);
+          REQUIRE(hex->nfunctions() == 64);
+          REQUIRE(hex->nfunctions_local() == 8);
           REQUIRE(shapefn.sum() == Approx(1.).epsilon(Tolerance));
 
           REQUIRE(shapefn(0) == Approx(0.125).epsilon(Tolerance));
@@ -812,6 +816,8 @@ TEST_CASE("Hexahedron bspline elements are checked",
 
           // Check shape function
           REQUIRE(shapefn.size() == 48);
+          REQUIRE(hex->nfunctions() == 48);
+          REQUIRE(hex->nfunctions_local() == 8);
           REQUIRE(shapefn.sum() == Approx(1.).epsilon(Tolerance));
 
           REQUIRE(shapefn(0) == Approx(0.0833333).epsilon(Tolerance));
@@ -1040,6 +1046,8 @@ TEST_CASE("Hexahedron bspline elements are checked",
 
           // Check shape function
           REQUIRE(shapefn.size() == 36);
+          REQUIRE(hex->nfunctions() == 36);
+          REQUIRE(hex->nfunctions_local() == 8);
           REQUIRE(shapefn.sum() == Approx(1.).epsilon(Tolerance));
 
           REQUIRE(shapefn(0) == Approx(0.111111).epsilon(Tolerance));
@@ -1227,6 +1235,8 @@ TEST_CASE("Hexahedron bspline elements are checked",
 
           // Check shape function
           REQUIRE(shapefn.size() == 27);
+          REQUIRE(hex->nfunctions() == 27);
+          REQUIRE(hex->nfunctions_local() == 8);
           REQUIRE(shapefn.sum() == Approx(1.).epsilon(Tolerance));
 
           REQUIRE(shapefn(0) == Approx(0.0740741).epsilon(Tolerance));

--- a/tests/elements/hexahedron_element_test.cc
+++ b/tests/elements/hexahedron_element_test.cc
@@ -31,6 +31,8 @@ TEST_CASE("Hexahedron elements are checked", "[hex][element][3D]") {
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
+      REQUIRE(hex->nfunctions() == nfunctions);
+      REQUIRE(hex->nfunctions_local() == nfunctions);
 
       REQUIRE(shapefn(0) == Approx(0.125).epsilon(Tolerance));
       REQUIRE(shapefn(1) == Approx(0.125).epsilon(Tolerance));

--- a/tests/elements/hexahedron_gimp_element_test.cc
+++ b/tests/elements/hexahedron_gimp_element_test.cc
@@ -42,6 +42,8 @@ TEST_CASE("Hexahedron gimp elements are checked", "[hex][element][3D][gimp]") {
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
+      REQUIRE(hex->nfunctions() == nfunctions);
+      REQUIRE(hex->nfunctions_local() == 8);
 
       REQUIRE(shapefn(0) == Approx(0.125).epsilon(Tolerance));
       REQUIRE(shapefn(1) == Approx(0.125).epsilon(Tolerance));
@@ -326,6 +328,8 @@ TEST_CASE("Hexahedron gimp elements are checked", "[hex][element][3D][gimp]") {
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
+      REQUIRE(hex->nfunctions() == nfunctions);
+      REQUIRE(hex->nfunctions_local() == 8);
 
       REQUIRE(shapefn(0) == Approx(0.00920077734).epsilon(Tolerance));
       REQUIRE(shapefn(1) == Approx(0.0815575078).epsilon(Tolerance));
@@ -616,6 +620,8 @@ TEST_CASE("Hexahedron gimp elements are checked", "[hex][element][3D][gimp]") {
 
       // Check shape function
       REQUIRE(shapefn.size() == 8);
+      REQUIRE(hex->nfunctions() == 8);
+      REQUIRE(hex->nfunctions_local() == 8);
 
       REQUIRE(shapefn(0) == Approx(0.125).epsilon(Tolerance));
       REQUIRE(shapefn(1) == Approx(0.125).epsilon(Tolerance));

--- a/tests/elements/hexahedron_gimp_element_test.cc
+++ b/tests/elements/hexahedron_gimp_element_test.cc
@@ -620,7 +620,7 @@ TEST_CASE("Hexahedron gimp elements are checked", "[hex][element][3D][gimp]") {
 
       // Check shape function
       REQUIRE(shapefn.size() == 8);
-      REQUIRE(hex->nfunctions() == 8);
+      REQUIRE(hex->nfunctions() == 64);
       REQUIRE(hex->nfunctions_local() == 8);
 
       REQUIRE(shapefn(0) == Approx(0.125).epsilon(Tolerance));

--- a/tests/elements/hexahedron_lme_element_test.cc
+++ b/tests/elements/hexahedron_lme_element_test.cc
@@ -33,6 +33,8 @@ TEST_CASE("Hexahedron lme elements are checked", "[hex][element][3D][lme]") {
 
       // Check shape function
       REQUIRE(shapefn.size() == 8);
+      REQUIRE(hex->nfunctions() == 8);
+      REQUIRE(hex->nfunctions_local() == 8);
 
       REQUIRE(shapefn(0) == Approx(0.125).epsilon(Tolerance));
       REQUIRE(shapefn(1) == Approx(0.125).epsilon(Tolerance));
@@ -163,6 +165,8 @@ TEST_CASE("Hexahedron lme elements are checked", "[hex][element][3D][lme]") {
 
           // Check shape function
           REQUIRE(shapefn.size() == 64);
+          REQUIRE(hex->nfunctions() == 64);
+          REQUIRE(hex->nfunctions_local() == 8);
           REQUIRE(shapefn.sum() == Approx(1.).epsilon(Tolerance));
 
           REQUIRE(shapefn(0) == Approx(0.125).epsilon(Tolerance));
@@ -780,6 +784,8 @@ TEST_CASE("Hexahedron lme elements are checked", "[hex][element][3D][lme]") {
 
       // Check shape function
       REQUIRE(shapefn.size() == 216);
+      REQUIRE(hex->nfunctions() == 216);
+      REQUIRE(hex->nfunctions_local() == 8);
       REQUIRE(shapefn.sum() == Approx(1.).epsilon(Tolerance));
 
       Eigen::VectorXd shapefn_ans = Eigen::VectorXd::Constant(216, 1.0);

--- a/tests/elements/quadrilateral_bspline_element_test.cc
+++ b/tests/elements/quadrilateral_bspline_element_test.cc
@@ -32,6 +32,8 @@ TEST_CASE("Quadrilateral bspline elements are checked",
 
       // Check shape function
       REQUIRE(shapefn.size() == 4);
+      REQUIRE(quad->nfunctions() == 4);
+      REQUIRE(quad->nfunctions_local() == 4);
 
       REQUIRE(shapefn(0) == Approx(0.25).epsilon(Tolerance));
       REQUIRE(shapefn(1) == Approx(0.25).epsilon(Tolerance));
@@ -106,6 +108,8 @@ TEST_CASE("Quadrilateral bspline elements are checked",
 
           // Check shape function
           REQUIRE(shapefn.size() == 16);
+          REQUIRE(quad->nfunctions() == 16);
+          REQUIRE(quad->nfunctions_local() == 4);
           REQUIRE(shapefn.sum() == Approx(1.).epsilon(Tolerance));
 
           REQUIRE(shapefn(0) == Approx(0.25).epsilon(Tolerance));
@@ -304,6 +308,8 @@ TEST_CASE("Quadrilateral bspline elements are checked",
 
         // Check shape function
         REQUIRE(shapefn.size() == 12);
+        REQUIRE(quad->nfunctions() == 12);
+        REQUIRE(quad->nfunctions_local() == 4);
         REQUIRE(shapefn.sum() == Approx(1.).epsilon(Tolerance));
 
         REQUIRE(shapefn(0) == Approx(0.3333333333).epsilon(Tolerance));
@@ -395,6 +401,8 @@ TEST_CASE("Quadrilateral bspline elements are checked",
 
         // Check shape function
         REQUIRE(shapefn.size() == 9);
+        REQUIRE(quad->nfunctions() == 9);
+        REQUIRE(quad->nfunctions_local() == 4);
         REQUIRE(shapefn.sum() == Approx(1.).epsilon(Tolerance));
 
         REQUIRE(shapefn(0) == Approx(0.444444).epsilon(Tolerance));

--- a/tests/elements/quadrilateral_element_test.cc
+++ b/tests/elements/quadrilateral_element_test.cc
@@ -31,6 +31,8 @@ TEST_CASE("Quadrilateral elements are checked", "[quad][element][2D]") {
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
+      REQUIRE(quad->nfunctions() == nfunctions);
+      REQUIRE(quad->nfunctions_local() == nfunctions);
 
       REQUIRE(shapefn(0) == Approx(0.25).epsilon(Tolerance));
       REQUIRE(shapefn(1) == Approx(0.25).epsilon(Tolerance));

--- a/tests/elements/quadrilateral_gimp_element_test.cc
+++ b/tests/elements/quadrilateral_gimp_element_test.cc
@@ -44,6 +44,8 @@ TEST_CASE("Quadrilateral gimp elements are checked",
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
+      REQUIRE(quad->nfunctions() == nfunctions);
+      REQUIRE(quad->nfunctions_local() == 4);
 
       REQUIRE(shapefn(0) == Approx(0.25).epsilon(Tolerance));
       REQUIRE(shapefn(1) == Approx(0.25).epsilon(Tolerance));
@@ -120,6 +122,8 @@ TEST_CASE("Quadrilateral gimp elements are checked",
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
+      REQUIRE(quad->nfunctions() == nfunctions);
+      REQUIRE(quad->nfunctions_local() == 4);
 
       REQUIRE(shapefn(0) == Approx(1.0).epsilon(Tolerance));
       REQUIRE(shapefn(1) == Approx(0.0).epsilon(Tolerance));
@@ -198,6 +202,8 @@ TEST_CASE("Quadrilateral gimp elements are checked",
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
+      REQUIRE(quad->nfunctions() == nfunctions);
+      REQUIRE(quad->nfunctions_local() == 4);
 
       REQUIRE(shapefn(0) == Approx(0.0).epsilon(Tolerance));
       REQUIRE(shapefn(1) == Approx(0.0).epsilon(Tolerance));
@@ -276,6 +282,8 @@ TEST_CASE("Quadrilateral gimp elements are checked",
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
+      REQUIRE(quad->nfunctions() == nfunctions);
+      REQUIRE(quad->nfunctions_local() == 4);
 
       REQUIRE(shapefn(0) == Approx(0.80550625).epsilon(Tolerance));
       REQUIRE(shapefn(1) == Approx(0.090871875).epsilon(Tolerance));
@@ -354,6 +362,8 @@ TEST_CASE("Quadrilateral gimp elements are checked",
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
+      REQUIRE(quad->nfunctions() == nfunctions);
+      REQUIRE(quad->nfunctions_local() == 4);
 
       REQUIRE(shapefn(0) == Approx(0.0102515625).epsilon(Tolerance));
       REQUIRE(shapefn(1) == Approx(0.090871875).epsilon(Tolerance));

--- a/tests/elements/quadrilateral_lme_element_test.cc
+++ b/tests/elements/quadrilateral_lme_element_test.cc
@@ -32,6 +32,8 @@ TEST_CASE("Quadrilateral lme elements are checked",
 
       // Check shape function
       REQUIRE(shapefn.size() == 4);
+      REQUIRE(quad->nfunctions() == 4);
+      REQUIRE(quad->nfunctions_local() == 4);
 
       REQUIRE(shapefn(0) == Approx(0.25).epsilon(Tolerance));
       REQUIRE(shapefn(1) == Approx(0.25).epsilon(Tolerance));
@@ -114,6 +116,8 @@ TEST_CASE("Quadrilateral lme elements are checked",
 
           // Check shape function
           REQUIRE(shapefn.size() == 16);
+          REQUIRE(quad->nfunctions() == 16);
+          REQUIRE(quad->nfunctions_local() == 4);
           REQUIRE(shapefn.sum() == Approx(1.).epsilon(Tolerance));
 
           REQUIRE(shapefn(0) == Approx(0.25).epsilon(Tolerance));
@@ -350,6 +354,8 @@ TEST_CASE("Quadrilateral lme elements are checked",
 
       // Check shape function
       REQUIRE(shapefn.size() == 100);
+      REQUIRE(quad->nfunctions() == 100);
+      REQUIRE(quad->nfunctions_local() == 4);
       REQUIRE(shapefn.sum() == Approx(1.).epsilon(Tolerance));
 
       Eigen::VectorXd shapefn_ans = Eigen::VectorXd::Constant(100, 1.0);

--- a/tests/elements/tetrahedron_element_test.cc
+++ b/tests/elements/tetrahedron_element_test.cc
@@ -31,6 +31,8 @@ TEST_CASE("Tetrahedron elements are checked", "[tet][element][3D]") {
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
+      REQUIRE(tet->nfunctions() == nfunctions);
+      REQUIRE(tet->nfunctions_local() == nfunctions);
 
       REQUIRE(shapefn(0) == Approx(1.0).epsilon(Tolerance));
       REQUIRE(shapefn(1) == Approx(0.0).epsilon(Tolerance));
@@ -67,6 +69,8 @@ TEST_CASE("Tetrahedron elements are checked", "[tet][element][3D]") {
       auto shapefn = tet->shapefn(coords, zero, zero_matrix);
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
+      REQUIRE(tet->nfunctions() == nfunctions);
+      REQUIRE(tet->nfunctions_local() == nfunctions);
 
       REQUIRE(shapefn(0) == Approx(0.0).epsilon(Tolerance));
       REQUIRE(shapefn(1) == Approx(1.0 / 3).epsilon(Tolerance));
@@ -103,6 +107,8 @@ TEST_CASE("Tetrahedron elements are checked", "[tet][element][3D]") {
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
+      REQUIRE(tet->nfunctions() == nfunctions);
+      REQUIRE(tet->nfunctions_local() == nfunctions);
 
       REQUIRE(shapefn(0) == Approx(1.0).epsilon(Tolerance));
       REQUIRE(shapefn(1) == Approx(0.0).epsilon(Tolerance));
@@ -121,6 +127,8 @@ TEST_CASE("Tetrahedron elements are checked", "[tet][element][3D]") {
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
+      REQUIRE(tet->nfunctions() == nfunctions);
+      REQUIRE(tet->nfunctions_local() == nfunctions);
 
       REQUIRE(shapefn(0) == Approx(1.0).epsilon(Tolerance));
       REQUIRE(shapefn(1) == Approx(0.0).epsilon(Tolerance));

--- a/tests/elements/triangle_element_test.cc
+++ b/tests/elements/triangle_element_test.cc
@@ -31,6 +31,8 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
+      REQUIRE(tri->nfunctions() == nfunctions);
+      REQUIRE(tri->nfunctions_local() == nfunctions);
 
       REQUIRE(shapefn(0) == Approx(1.0).epsilon(Tolerance));
       REQUIRE(shapefn(1) == Approx(0.0).epsilon(Tolerance));
@@ -57,6 +59,8 @@ TEST_CASE("Triangle elements are checked", "[tri][element][2D]") {
 
       // Check shape function
       REQUIRE(shapefn.size() == nfunctions);
+      REQUIRE(tri->nfunctions() == nfunctions);
+      REQUIRE(tri->nfunctions_local() == nfunctions);
 
       REQUIRE(shapefn(0) == Approx(0.334).epsilon(Tolerance));
       REQUIRE(shapefn(1) == Approx(0.333).epsilon(Tolerance));

--- a/tests/elements/triangle_lme_element_test.cc
+++ b/tests/elements/triangle_lme_element_test.cc
@@ -31,6 +31,8 @@ TEST_CASE("Triangle lme elements are checked", "[tri][element][2D][lme]") {
 
       // Check shape function
       REQUIRE(shapefn.size() == 3);
+      REQUIRE(tri->nfunctions() == 3);
+      REQUIRE(tri->nfunctions_local() == 3);
 
       REQUIRE(shapefn(0) == Approx(0.66666666666).epsilon(Tolerance));
       REQUIRE(shapefn(1) == Approx(0.16666666666).epsilon(Tolerance));
@@ -179,6 +181,8 @@ TEST_CASE("Triangle lme elements are checked", "[tri][element][2D][lme]") {
 
           // Check shape function
           REQUIRE(shapefn.size() == 14);
+          REQUIRE(tri->nfunctions() == 14);
+          REQUIRE(tri->nfunctions_local() == 3);
           REQUIRE(shapefn.sum() == Approx(1.).epsilon(Tolerance));
 
           REQUIRE(shapefn(0) == Approx(1. / 3.).epsilon(Tolerance));
@@ -286,6 +290,8 @@ TEST_CASE("Triangle lme elements are checked", "[tri][element][2D][lme]") {
 
       // Check shape function
       REQUIRE(shapefn.size() == 108);
+      REQUIRE(tri->nfunctions() == 108);
+      REQUIRE(tri->nfunctions_local() == 3);
       REQUIRE(shapefn.sum() == Approx(1.).epsilon(Tolerance));
 
       Eigen::VectorXd shapefn_ans = Eigen::VectorXd::Constant(108, 1.0);
@@ -442,6 +448,8 @@ TEST_CASE("Triangle lme elements are checked", "[tri][element][2D][lme]") {
 
       // Check shape function
       REQUIRE(shapefn.size() == 108);
+      REQUIRE(tri->nfunctions() == 108);
+      REQUIRE(tri->nfunctions_local() == 3);
       REQUIRE(shapefn.sum() == Approx(1.).epsilon(Tolerance));
 
       // Compute gradient of shape functions


### PR DESCRIPTION
**Describe the PR**
This PR introduces a fix to the free surface detection routine for nonlocal elements. Instead of using the regular `node_id`, which includes non-local nodes from adjacent cells, we should use `local_nodes_id`, which only contains the id of nodes located in the current cell of interest.

**Related Issues/PRs**
N/A

**Additional context**
No change in the performance for local shape function. Also, tests are added to maintain code coverage.
