### PR TITLE
[Fluid] Add a fix in nonlocal free-surface detection algorithm

### DIFF
--- a/include/linear_solvers/linear_solvers/krylov_petsc.tcc
+++ b/include/linear_solvers/linear_solvers/krylov_petsc.tcc
@@ -130,6 +130,7 @@ Eigen::VectorXd mpm::KrylovPETSC<Traits>::solve(
 
     // Warn if solver does not converge
     if (reason < 0) {
+      KSPConvergedReasonView(solver, PETSC_VIEWER_STDOUT_WORLD);
       PetscPrintf(MPI_COMM_WORLD,
                   "\nKrylov PETSC solver \"%s\" with \"%s\" preconditioner "
                   "DIVERGED, try to modify the preconditioner, set tolerance "

--- a/include/mesh/mesh.h
+++ b/include/mesh/mesh.h
@@ -538,10 +538,12 @@ class Mesh {
   //! \ingroup MultiPhase
   //! \param[in] method Type of method to use
   //! \param[in] volume_tolerance for volume_fraction approach
+  //! \param[in] cell_neighbourhood for nonlocal free surface detection
   //! \retval status Status of compute_free_surface
   bool compute_free_surface(
       const std::string& method = "density",
-      double volume_tolerance = std::numeric_limits<unsigned>::epsilon());
+      double volume_tolerance = std::numeric_limits<unsigned>::epsilon(),
+      unsigned cell_neighbourhood = 0);
 
   //! Compute free surface by density method
   //! \ingroup MultiPhase
@@ -549,9 +551,11 @@ class Mesh {
   //! & Soga, 2017) and density ratio comparison (Hamad, 2015). This method is
   //! fast, but less accurate.
   //! \param[in] volume_tolerance for volume_fraction approach
+  //! \param[in] cell_neighbourhood for nonlocal free surface detection
   //! \retval status Status of compute_free_surface
   bool compute_free_surface_by_density(
-      double volume_tolerance = std::numeric_limits<unsigned>::epsilon());
+      double volume_tolerance = std::numeric_limits<unsigned>::epsilon(),
+      unsigned cell_neighbourhood = 0);
 
   //! Compute free surface by geometry method
   //! \ingroup MultiPhase
@@ -561,9 +565,11 @@ class Mesh {
   //! 2017), (2) Density comparison approach as (Hamad, 2015), and (3) Geometry
   //! based approach as (Marrone et al. 2010)
   //! \param[in] volume_tolerance for volume_fraction approach
+  //! \param[in] cell_neighbourhood for nonlocal free surface detection
   //! \retval status Status of compute_free_surface
   bool compute_free_surface_by_geometry(
-      double volume_tolerance = std::numeric_limits<unsigned>::epsilon());
+      double volume_tolerance = std::numeric_limits<unsigned>::epsilon(),
+      unsigned cell_neighbourhood = 0);
 
   //! \ingroup MultiPhase
   //! \retval id_set Set of free surface node ids

--- a/include/mesh/mesh_multiphase.tcc
+++ b/include/mesh/mesh_multiphase.tcc
@@ -1,25 +1,29 @@
 //! Compute free surface cells, nodes, and particles
 template <unsigned Tdim>
 bool mpm::Mesh<Tdim>::compute_free_surface(const std::string& method,
-                                           double volume_tolerance) {
+                                           double volume_tolerance,
+                                           unsigned cell_neighbourhood) {
   if (method == "density") {
-    return this->compute_free_surface_by_density(volume_tolerance);
+    return this->compute_free_surface_by_density(volume_tolerance,
+                                                 cell_neighbourhood);
   } else if (method == "geometry") {
-    return this->compute_free_surface_by_geometry(volume_tolerance);
+    return this->compute_free_surface_by_geometry(volume_tolerance,
+                                                  cell_neighbourhood);
   } else {
     console_->info(
         "The selected free-surface computation method: {}\n is not "
         "available. "
         "Using density approach as default method.",
         method);
-    return this->compute_free_surface_by_density(volume_tolerance);
+    return this->compute_free_surface_by_density(volume_tolerance,
+                                                 cell_neighbourhood);
   }
 }
 
 //! Compute free surface cells, nodes, and particles by density and geometry
 template <unsigned Tdim>
 bool mpm::Mesh<Tdim>::compute_free_surface_by_geometry(
-    double volume_tolerance) {
+    double volume_tolerance, unsigned cell_neighbourhood) {
   bool status = true;
 
   // Reset free surface cell and particles
@@ -44,6 +48,24 @@ bool mpm::Mesh<Tdim>::compute_free_surface_by_geometry(
   // Compute and assign volume fraction to each cell
   this->compute_cell_vol_fraction();
 
+  // Recursive lambda function to check neighbours
+  auto fs_neighbour_check =
+      [&](const std::shared_ptr<mpm::Cell<Tdim>>& cell_ptr,
+          unsigned neighbourhood, auto&& fs_neighbour_check) {
+        if (neighbourhood == 0) {
+          if (cell_ptr->volume_fraction() < volume_tolerance)
+            for (const auto id : cell_ptr->local_nodes_id()) {
+              map_nodes_[id]->assign_free_surface(true);
+            }
+          return;
+        } else {
+          for (const auto neighbour_cell_id : cell_ptr->neighbours())
+            fs_neighbour_check(map_cells_[neighbour_cell_id], neighbourhood - 1,
+                               fs_neighbour_check);
+        }
+        return;
+      };
+
   // First, we detect the cell with possible free surfaces
   // Compute boundary cells and nodes based on geometry
   std::set<mpm::Index> free_surface_candidate_cells;
@@ -55,9 +77,7 @@ bool mpm::Mesh<Tdim>::compute_free_surface_by_geometry(
       const auto& node_id = (*citr)->nodes_id();
       if ((*citr)->volume_fraction() < volume_tolerance) {
         candidate_cell = true;
-        for (const auto id : (*citr)->local_nodes_id()) {
-          map_nodes_[id]->assign_free_surface(true);
-        }
+        fs_neighbour_check((*citr), cell_neighbourhood, fs_neighbour_check);
       } else {
         // Loop over neighbouring cells
         for (const auto neighbour_cell_id : (*citr)->neighbours()) {
@@ -231,7 +251,8 @@ bool mpm::Mesh<Tdim>::compute_free_surface_by_geometry(
 
 //! Compute free surface cells, nodes, and particles by density
 template <unsigned Tdim>
-bool mpm::Mesh<Tdim>::compute_free_surface_by_density(double volume_tolerance) {
+bool mpm::Mesh<Tdim>::compute_free_surface_by_density(
+    double volume_tolerance, unsigned cell_neighbourhood) {
   bool status = true;
 
   // Get number of MPI ranks
@@ -309,6 +330,25 @@ bool mpm::Mesh<Tdim>::compute_free_surface_by_density(double volume_tolerance) {
   }
 #endif
 
+  // Recursive lambda function to check neighbours
+  auto fs_neighbour_check =
+      [&](const std::shared_ptr<mpm::Cell<Tdim>>& cell_ptr,
+          unsigned neighbourhood, auto&& fs_neighbour_check) {
+        if (neighbourhood == 0) {
+          if (cell_ptr->volume_fraction() < volume_tolerance) {
+            for (const auto id : cell_ptr->local_nodes_id()) {
+              map_nodes_[id]->assign_free_surface(true);
+            }
+          }
+          return;
+        } else {
+          for (const auto neighbour_cell_id : cell_ptr->neighbours())
+            fs_neighbour_check(map_cells_[neighbour_cell_id], neighbourhood - 1,
+                               fs_neighbour_check);
+        }
+        return;
+      };
+
 #pragma omp parallel for schedule(runtime)
   // Compute boundary cells and nodes based on geometry
   for (auto citr = this->cells_.cbegin(); citr != this->cells_.cend(); ++citr) {
@@ -337,9 +377,7 @@ bool mpm::Mesh<Tdim>::compute_free_surface_by_density(double volume_tolerance) {
       if (!internal) {
         if ((*citr)->volume_fraction() < volume_tolerance) {
           cell_at_interface = true;
-          for (const auto id : (*citr)->local_nodes_id()) {
-            map_nodes_[id]->assign_free_surface(cell_at_interface);
-          }
+          fs_neighbour_check((*citr), cell_neighbourhood, fs_neighbour_check);
         } else {
           for (const auto neighbour_cell_id : (*citr)->neighbours()) {
             if (map_cells_[neighbour_cell_id]->volume_fraction() <

--- a/include/solvers/mpm_explicit_twophase.h
+++ b/include/solvers/mpm_explicit_twophase.h
@@ -77,7 +77,7 @@ class MPMExplicitTwoPhase : public MPMBase<Tdim> {
   //! Compute free surface
   std::string free_surface_detection_;
   //! Volume tolerance for free surface
-  double volume_tolerance_{0.};
+  double fs_vol_tolerance_{0.25};
 
 };  // MPMExplicit class
 }  // namespace mpm

--- a/include/solvers/mpm_explicit_twophase.h
+++ b/include/solvers/mpm_explicit_twophase.h
@@ -68,6 +68,8 @@ class MPMExplicitTwoPhase : public MPMBase<Tdim> {
   using mpm::MPMBase<Tdim>::damping_factor_;
   //! Locate particles
   using mpm::MPMBase<Tdim>::locate_particles_;
+  //! Nonlocal cell neighbourhood
+  using mpm::MPMBase<Tdim>::cell_neighbourhood_;
 
  private:
   //! Pressure smoothing

--- a/include/solvers/mpm_explicit_twophase.tcc
+++ b/include/solvers/mpm_explicit_twophase.tcc
@@ -79,7 +79,6 @@ bool mpm::MPMExplicitTwoPhase<Tdim>::solve() {
   free_surface_detection_ = "none";
   if (analysis_.find("free_surface_detection") != analysis_.end()) {
     // Get method to detect free surface detection
-    free_surface_detection_ = "density";
     if (analysis_["free_surface_detection"].contains("type"))
       free_surface_detection_ = analysis_["free_surface_detection"]["type"]
                                     .template get<std::string>();
@@ -89,8 +88,8 @@ bool mpm::MPMExplicitTwoPhase<Tdim>::solve() {
   }
 
 #ifdef USE_MPI
-  if ((free_surface_detection_ != "none" ||
-       free_surface_detection_ != "density") &&
+  if ((free_surface_detection_ != "density" ||
+       free_surface_detection_ != "none") &&
       mpi_size > 1) {
     console_->warn(
         "The free-surface detection in MPI setting is automatically set to "

--- a/include/solvers/mpm_explicit_twophase.tcc
+++ b/include/solvers/mpm_explicit_twophase.tcc
@@ -84,9 +84,22 @@ bool mpm::MPMExplicitTwoPhase<Tdim>::solve() {
       free_surface_detection_ = analysis_["free_surface_detection"]["type"]
                                     .template get<std::string>();
     // Get volume tolerance for free surface
-    volume_tolerance_ = analysis_["free_surface_detection"]["volume_tolerance"]
+    fs_vol_tolerance_ = analysis_["free_surface_detection"]["volume_tolerance"]
                             .template get<double>();
   }
+
+#ifdef USE_MPI
+  if ((free_surface_detection_ != "none" ||
+       free_surface_detection_ != "density") &&
+      mpi_size > 1) {
+    console_->warn(
+        "The free-surface detection in MPI setting is automatically set to "
+        "default: "
+        "\'density\'. Only \'none\' and \'density\' free-surface detection "
+        "algorithm are supported for MPI.");
+    free_surface_detection_ = "density";
+  }
+#endif
 
   // Initialise material
   this->initialise_materials();
@@ -220,7 +233,7 @@ bool mpm::MPMExplicitTwoPhase<Tdim>::solve() {
 
     // Compute free surface cells, nodes, and particles
     if (free_surface_detection_ != "none") {
-      mesh_->compute_free_surface(free_surface_detection_, volume_tolerance_);
+      mesh_->compute_free_surface(free_surface_detection_, fs_vol_tolerance_);
 
       // Spawn a task for initializing pressure at free surface
 #pragma omp parallel sections

--- a/include/solvers/mpm_explicit_twophase.tcc
+++ b/include/solvers/mpm_explicit_twophase.tcc
@@ -88,8 +88,8 @@ bool mpm::MPMExplicitTwoPhase<Tdim>::solve() {
   }
 
 #ifdef USE_MPI
-  if ((free_surface_detection_ != "density" ||
-       free_surface_detection_ != "none") &&
+  if (!(free_surface_detection_ == "density" ||
+        free_surface_detection_ == "none") &&
       mpi_size > 1) {
     console_->warn(
         "The free-surface detection in MPI setting is automatically set to "

--- a/include/solvers/mpm_explicit_twophase.tcc
+++ b/include/solvers/mpm_explicit_twophase.tcc
@@ -232,7 +232,8 @@ bool mpm::MPMExplicitTwoPhase<Tdim>::solve() {
 
     // Compute free surface cells, nodes, and particles
     if (free_surface_detection_ != "none") {
-      mesh_->compute_free_surface(free_surface_detection_, fs_vol_tolerance_);
+      mesh_->compute_free_surface(free_surface_detection_, fs_vol_tolerance_,
+                                  cell_neighbourhood_);
 
       // Spawn a task for initializing pressure at free surface
 #pragma omp parallel sections

--- a/include/solvers/mpm_implicit.h
+++ b/include/solvers/mpm_implicit.h
@@ -115,7 +115,7 @@ class MPMImplicit : public MPMBase<Tdim> {
   using mpm::MPMBase<Tdim>::damping_factor_;
   //! Locate particles
   using mpm::MPMBase<Tdim>::locate_particles_;
-  //! Nonlocal neighbourhood
+  //! Nonlocal node neighbourhood
   using mpm::MPMBase<Tdim>::node_neighbourhood_;
   //! Update deformation gradient
   using mpm::MPMBase<Tdim>::update_defgrad_;

--- a/include/solvers/mpm_semi_implicit_navierstokes.h
+++ b/include/solvers/mpm_semi_implicit_navierstokes.h
@@ -90,7 +90,7 @@ class MPMSemiImplicitNavierStokes : public MPMBase<Tdim> {
   //! Method to detect free surface detection
   std::string free_surface_detection_;
   //! Volume tolerance for free surface
-  double volume_tolerance_{0};
+  double fs_vol_tolerance_{0.25};
 
 };  // MPMSemiImplicit class
 }  // namespace mpm

--- a/include/solvers/mpm_semi_implicit_navierstokes.h
+++ b/include/solvers/mpm_semi_implicit_navierstokes.h
@@ -75,7 +75,9 @@ class MPMSemiImplicitNavierStokes : public MPMBase<Tdim> {
   using mpm::MPMBase<Tdim>::mesh_;
   //! Materials
   using mpm::MPMBase<Tdim>::materials_;
-  //! Nonlocal neighbourhood
+  //! Nonlocal cell neighbourhood
+  using mpm::MPMBase<Tdim>::cell_neighbourhood_;
+  //! Nonlocal node neighbourhood
   using mpm::MPMBase<Tdim>::node_neighbourhood_;
   //! Pressure smoothing
   bool pressure_smoothing_{false};

--- a/include/solvers/mpm_semi_implicit_navierstokes.tcc
+++ b/include/solvers/mpm_semi_implicit_navierstokes.tcc
@@ -421,7 +421,6 @@ bool mpm::MPMSemiImplicitNavierStokes<Tdim>::initialise_matrix() {
     free_surface_detection_ = "density";
     if (analysis_.find("free_surface_detection") != analysis_.end()) {
       // Get method to detect free surface detection
-      free_surface_detection_ = "density";
       if (analysis_["free_surface_detection"].contains("type"))
         free_surface_detection_ = analysis_["free_surface_detection"]["type"]
                                       .template get<std::string>();
@@ -432,8 +431,8 @@ bool mpm::MPMSemiImplicitNavierStokes<Tdim>::initialise_matrix() {
     }
 
 #ifdef USE_MPI
-    if ((free_surface_detection_ != "none" ||
-         free_surface_detection_ != "density") &&
+    if ((free_surface_detection_ != "density" ||
+         free_surface_detection_ != "none") &&
         mpi_size > 1) {
       console_->warn(
           "The free-surface detection in MPI setting is automatically set to "

--- a/include/solvers/mpm_semi_implicit_navierstokes.tcc
+++ b/include/solvers/mpm_semi_implicit_navierstokes.tcc
@@ -171,7 +171,8 @@ bool mpm::MPMSemiImplicitNavierStokes<Tdim>::solve() {
 
     // Compute free surface cells, nodes, and particles
     if (free_surface_detection_ != "none") {
-      mesh_->compute_free_surface(free_surface_detection_, fs_vol_tolerance_);
+      mesh_->compute_free_surface(free_surface_detection_, fs_vol_tolerance_,
+                                  cell_neighbourhood_);
 
       // Spawn a task for initializing pressure at free surface
 #pragma omp parallel sections

--- a/include/solvers/mpm_semi_implicit_navierstokes.tcc
+++ b/include/solvers/mpm_semi_implicit_navierstokes.tcc
@@ -432,8 +432,8 @@ bool mpm::MPMSemiImplicitNavierStokes<Tdim>::initialise_matrix() {
     }
 
 #ifdef USE_MPI
-    if ((free_surface_detection_ != "density" ||
-         free_surface_detection_ != "none") &&
+    if (!(free_surface_detection_ == "density" ||
+          free_surface_detection_ == "none") &&
         mpi_size > 1) {
       console_->warn(
           "The free-surface detection in MPI setting is automatically set to "

--- a/include/solvers/mpm_semi_implicit_twophase.h
+++ b/include/solvers/mpm_semi_implicit_twophase.h
@@ -104,7 +104,7 @@ class MPMSemiImplicitTwoPhase : public MPMBase<Tdim> {
   //! Method to detect free surface detection
   std::string free_surface_detection_;
   //! Volume tolerance for free surface
-  double volume_tolerance_{0};
+  double fs_vol_tolerance_{0.25};
 
 };  // MPMSemiImplicit class
 }  // namespace mpm

--- a/include/solvers/mpm_semi_implicit_twophase.h
+++ b/include/solvers/mpm_semi_implicit_twophase.h
@@ -85,7 +85,9 @@ class MPMSemiImplicitTwoPhase : public MPMBase<Tdim> {
   using mpm::MPMBase<Tdim>::mesh_;
   //! Materials
   using mpm::MPMBase<Tdim>::materials_;
-  //! Nonlocal neighbourhood
+  //! Nonlocal cell neighbourhood
+  using mpm::MPMBase<Tdim>::cell_neighbourhood_;
+  //! Nonlocal node neighbourhood
   using mpm::MPMBase<Tdim>::node_neighbourhood_;
   //! Node concentrated force
   using mpm::MPMBase<Tdim>::set_node_concentrated_force_;

--- a/include/solvers/mpm_semi_implicit_twophase.tcc
+++ b/include/solvers/mpm_semi_implicit_twophase.tcc
@@ -216,7 +216,8 @@ bool mpm::MPMSemiImplicitTwoPhase<Tdim>::solve() {
 
     // Compute free surface cells, nodes, and particles
     if (free_surface_detection_ != "none") {
-      mesh_->compute_free_surface(free_surface_detection_, fs_vol_tolerance_);
+      mesh_->compute_free_surface(free_surface_detection_, fs_vol_tolerance_,
+                                  cell_neighbourhood_);
 
       // Spawn a task for initializing pressure at free surface
 #pragma omp parallel sections

--- a/include/solvers/mpm_semi_implicit_twophase.tcc
+++ b/include/solvers/mpm_semi_implicit_twophase.tcc
@@ -215,21 +215,23 @@ bool mpm::MPMSemiImplicitTwoPhase<Tdim>::solve() {
 #endif
 
     // Compute free surface cells, nodes, and particles
-    mesh_->compute_free_surface(free_surface_detection_, volume_tolerance_);
+    if (free_surface_detection_ != "none") {
+      mesh_->compute_free_surface(free_surface_detection_, fs_vol_tolerance_);
 
-    // Spawn a task for initializing pressure at free surface
+      // Spawn a task for initializing pressure at free surface
 #pragma omp parallel sections
-    {
-#pragma omp section
       {
-        // Assign initial pressure for all free-surface particle
-        mesh_->iterate_over_particles_predicate(
-            std::bind(&mpm::ParticleBase<Tdim>::assign_pressure,
-                      std::placeholders::_1, 0.0, mpm::ParticlePhase::Liquid),
-            std::bind(&mpm::ParticleBase<Tdim>::free_surface,
-                      std::placeholders::_1));
-      }
-    }  // Wait to complete
+#pragma omp section
+        {
+          // Assign initial pressure for all free-surface particle
+          mesh_->iterate_over_particles_predicate(
+              std::bind(&mpm::ParticleBase<Tdim>::assign_pressure,
+                        std::placeholders::_1, 0.0, mpm::ParticlePhase::Liquid),
+              std::bind(&mpm::ParticleBase<Tdim>::free_surface,
+                        std::placeholders::_1));
+        }
+      }  // Wait to complete
+    }
 
     // Compute nodal velocity at the begining of time step
     mesh_->iterate_over_nodes_predicate(
@@ -452,6 +454,14 @@ template <unsigned Tdim>
 bool mpm::MPMSemiImplicitTwoPhase<Tdim>::initialise_matrix() {
   bool status = true;
   try {
+    // Initialise MPI size
+    int mpi_size = 1;
+
+#ifdef USE_MPI
+    // Get number of MPI ranks
+    MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
+#endif
+
     // Get matrix assembler type
     std::string assembler_type = analysis_["linear_solver"]["assembler_type"]
                                      .template get<std::string>();
@@ -493,10 +503,6 @@ bool mpm::MPMSemiImplicitTwoPhase<Tdim>::initialise_matrix() {
 
       // NOTE: Only KrylovPETSC solver is supported for MPI
 #ifdef USE_MPI
-      // Get number of MPI ranks
-      int mpi_size = 1;
-      MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
-
       if (solver_type != "KrylovPETSC" && mpi_size > 1) {
         console_->warn(
             "The linear solver in MPI setting is automatically set to "
@@ -540,12 +546,30 @@ bool mpm::MPMSemiImplicitTwoPhase<Tdim>::initialise_matrix() {
 
     // Get method to detect free surface detection
     free_surface_detection_ = "density";
-    if (analysis_["free_surface_detection"].contains("type"))
-      free_surface_detection_ = analysis_["free_surface_detection"]["type"]
-                                    .template get<std::string>();
-    // Get volume tolerance for free surface
-    volume_tolerance_ = analysis_["free_surface_detection"]["volume_tolerance"]
-                            .template get<double>();
+    if (analysis_.find("free_surface_detection") != analysis_.end()) {
+      // Get method to detect free surface detection
+      free_surface_detection_ = "density";
+      if (analysis_["free_surface_detection"].contains("type"))
+        free_surface_detection_ = analysis_["free_surface_detection"]["type"]
+                                      .template get<std::string>();
+      // Get volume tolerance for free surface
+      fs_vol_tolerance_ =
+          analysis_["free_surface_detection"]["volume_tolerance"]
+              .template get<double>();
+    }
+
+#ifdef USE_MPI
+    if ((free_surface_detection_ != "none" ||
+         free_surface_detection_ != "density") &&
+        mpi_size > 1) {
+      console_->warn(
+          "The free-surface detection in MPI setting is automatically set to "
+          "default: "
+          "\'density\'. Only \'none\' and \'density\' free-surface detection "
+          "algorithm are supported for MPI.");
+      free_surface_detection_ = "density";
+    }
+#endif
 
   } catch (std::exception& exception) {
     console_->error("{} #{}: {}\n", __FILE__, __LINE__, exception.what());

--- a/include/solvers/mpm_semi_implicit_twophase.tcc
+++ b/include/solvers/mpm_semi_implicit_twophase.tcc
@@ -548,7 +548,6 @@ bool mpm::MPMSemiImplicitTwoPhase<Tdim>::initialise_matrix() {
     free_surface_detection_ = "density";
     if (analysis_.find("free_surface_detection") != analysis_.end()) {
       // Get method to detect free surface detection
-      free_surface_detection_ = "density";
       if (analysis_["free_surface_detection"].contains("type"))
         free_surface_detection_ = analysis_["free_surface_detection"]["type"]
                                       .template get<std::string>();
@@ -559,8 +558,8 @@ bool mpm::MPMSemiImplicitTwoPhase<Tdim>::initialise_matrix() {
     }
 
 #ifdef USE_MPI
-    if ((free_surface_detection_ != "none" ||
-         free_surface_detection_ != "density") &&
+    if ((free_surface_detection_ != "density" ||
+         free_surface_detection_ != "none") &&
         mpi_size > 1) {
       console_->warn(
           "The free-surface detection in MPI setting is automatically set to "

--- a/include/solvers/mpm_semi_implicit_twophase.tcc
+++ b/include/solvers/mpm_semi_implicit_twophase.tcc
@@ -559,8 +559,8 @@ bool mpm::MPMSemiImplicitTwoPhase<Tdim>::initialise_matrix() {
     }
 
 #ifdef USE_MPI
-    if ((free_surface_detection_ != "density" ||
-         free_surface_detection_ != "none") &&
+    if (!(free_surface_detection_ == "density" ||
+          free_surface_detection_ == "none") &&
         mpi_size > 1) {
       console_->warn(
           "The free-surface detection in MPI setting is automatically set to "


### PR DESCRIPTION
**Describe the PR**
PR #71 previously added the capabilities to detect local elements in the vicinity of free surfaces, which reduce the "over" imposition region if the nonlocal elements are used. However, there is still some limitation to handle splashes and fragmentation of liquid particles in nonlocal elements. The splashes cause the coefficient matrix in the Poisson solver to be ill-conditioned and introduce spurious pressure value.

This PR fixes that issues and make the free-surface detection works better to handle splashes.

**Related Issues/PRs**
#71 

**Additional context**
1. I also refactored the free-surface detection default parameters in the semi-implicit solvers, i.e. Navier-Stokes and two-phase.
2. Some snapshots of a water drop in the old code show the ill-condition computation of pressure.
![image](https://user-images.githubusercontent.com/37140224/190843330-de4e8ac3-f3c8-4df7-8583-2e7e29095792.png)

The fix:
![image](https://user-images.githubusercontent.com/37140224/190843372-63f7f96b-86da-48df-a18c-e4509bb110f1.png)
