### PR TITLE
[Bugfix] Swap status and cell_id for better HDF5 experience

### DIFF
--- a/include/particles/pod_particles/pod_particle.h
+++ b/include/particles/pod_particles/pod_particle.h
@@ -38,10 +38,10 @@ typedef struct PODParticle {
   double defgrad_00, defgrad_01, defgrad_02;
   double defgrad_10, defgrad_11, defgrad_12;
   double defgrad_20, defgrad_21, defgrad_22;
-  // Index
-  mpm::Index cell_id;
   // Status
   bool status;
+  // Index
+  mpm::Index cell_id;
   // Material id
   unsigned material_id;
   // Number of state variables


### PR DESCRIPTION
**Describe the PR**
`PODParticle` struct needs to have the same order as data in `pod_particle.cc`.

I tested this by looking at a simple column at `step=0`. Its clear the particles should be in cells 0 thru 9.

![image](https://user-images.githubusercontent.com/62029065/191133227-3827a498-3bf9-4009-ada9-b3beb744af58.png)


## Pre-fix HDF5 seems to store `"cell_id"` with the `"status"` key:
```
df = pd.read_hdf(input_filename)
Id = np.array(df['id'])
Cell = np.array(df['cell_id'])
cells = np.array([Id[:], Cell[:]])
print(cells.transpose())

[[  0   1]
 [  1   1]
 [  2   1]
 ...
 [637   1]
 [638   1]
 [639   1]]
```
These are obviously wrong values for the `"cell_id"`. Also, the 2nd column will contain random garbage values at intermediate rows. 
```
df = pd.read_hdf(input_filename)
Id = np.array(df['id'])
Status = np.array(df['status'])
cells = np.array([Id[:], Status[:]])
print(cells.transpose())

[[  0   0]
 [  1   0]
 [  2   0]
 ...
 [637   9]
 [638   9]
 [639   9]]
```
The seemingly "true" values of `"cell_id"` are accessible if using `"status"`... Not helpful. 

## Post-fix HDF5 makes more sense to me:
```
df = pd.read_hdf(input_filename)
Id = np.array(df['id'])
Cell = np.array(df['cell_id'])
cells = np.array([Id[:], Cell[:]])
print(cells.transpose())

[[  0   0]
 [  1   0]
 [  2   0]
 ...
 [637   9]
 [638   9]
 [639   9]]
```