### PR TITLE
[Element] High-order elements jacobian and bmatrix computation

### DIFF
--- a/include/elements/2d/quadrilateral_lme_element.tcc
+++ b/include/elements/2d/quadrilateral_lme_element.tcc
@@ -313,7 +313,7 @@ inline std::vector<Eigen::MatrixXd> mpm::QuadrilateralLMEElement<Tdim>::bmatrix(
     VectorDim& lambda, const MatrixDim& deformation_gradient) const {
 
   // Get gradient shape functions
-  Eigen::MatrixXd grad_sf =
+  Eigen::MatrixXd grad_shapefn =
       this->grad_shapefn(xi, lambda, deformation_gradient);
 
   // B-Matrix
@@ -322,7 +322,7 @@ inline std::vector<Eigen::MatrixXd> mpm::QuadrilateralLMEElement<Tdim>::bmatrix(
 
   try {
     // Check if matrices dimensions are correct
-    if ((grad_sf.rows() != nodal_coordinates.rows()) ||
+    if ((grad_shapefn.rows() != nodal_coordinates.rows()) ||
         (xi.rows() != nodal_coordinates.cols()))
       throw std::runtime_error(
           "BMatrix - Jacobian calculation: Incorrect dimension of xi and "
@@ -331,14 +331,6 @@ inline std::vector<Eigen::MatrixXd> mpm::QuadrilateralLMEElement<Tdim>::bmatrix(
     console_->error("{} #{}: {}\n", __FILE__, __LINE__, exception.what());
     return bmatrix;
   }
-
-  // Jacobian dx_i/dxi_j
-  Eigen::Matrix<double, Tdim, Tdim> jacobian =
-      (grad_sf.transpose() * nodal_coordinates);
-
-  // Gradient shapefn of the cell
-  // dN/dx = [J]^-1 * dN/dxi
-  Eigen::MatrixXd grad_shapefn = grad_sf * (jacobian.inverse()).transpose();
 
   for (unsigned i = 0; i < this->nconnectivity_; ++i) {
     Eigen::Matrix<double, 3, Tdim> bi;
@@ -369,24 +361,9 @@ inline Eigen::Matrix<double, Tdim, Tdim>
         const VectorDim& xi, const Eigen::MatrixXd& nodal_coordinates,
         VectorDim& lambda, const MatrixDim& deformation_gradient) const {
 
-  // Get gradient shape functions
-  const Eigen::MatrixXd grad_shapefn =
-      this->grad_shapefn(xi, lambda, deformation_gradient);
-
-  try {
-    // Check if matrices dimensions are correct
-    if ((grad_shapefn.rows() != nodal_coordinates.rows()) ||
-        (xi.size() != nodal_coordinates.cols()))
-      throw std::runtime_error(
-          "Jacobian calculation: Incorrect dimension of xi and "
-          "nodal_coordinates");
-  } catch (std::exception& exception) {
-    console_->error("{} #{}: {}\n", __FILE__, __LINE__, exception.what());
-    return Eigen::Matrix<double, Tdim, Tdim>::Zero();
-  }
-
-  // Jacobian dx_i/dxi_j
-  return (grad_shapefn.transpose() * nodal_coordinates);
+  // Jacobian dx_i/dxi_j local
+  return this->jacobian_local(xi, nodal_coordinates.block(0, 0, 4, 2), lambda,
+                              deformation_gradient);
 }
 
 //! Compute Jacobian local with particle size and deformation gradient

--- a/include/elements/2d/triangle_lme_element.tcc
+++ b/include/elements/2d/triangle_lme_element.tcc
@@ -316,7 +316,7 @@ inline std::vector<Eigen::MatrixXd> mpm::TriangleLMEElement<Tdim>::bmatrix(
     VectorDim& lambda, const MatrixDim& deformation_gradient) const {
 
   // Get gradient shape functions
-  Eigen::MatrixXd grad_sf =
+  Eigen::MatrixXd grad_shapefn =
       this->grad_shapefn(xi, lambda, deformation_gradient);
 
   // B-Matrix
@@ -325,7 +325,7 @@ inline std::vector<Eigen::MatrixXd> mpm::TriangleLMEElement<Tdim>::bmatrix(
 
   try {
     // Check if matrices dimensions are correct
-    if ((grad_sf.rows() != nodal_coordinates.rows()) ||
+    if ((grad_shapefn.rows() != nodal_coordinates.rows()) ||
         (xi.rows() != nodal_coordinates.cols()))
       throw std::runtime_error(
           "BMatrix - Jacobian calculation: Incorrect dimension of xi and "
@@ -334,14 +334,6 @@ inline std::vector<Eigen::MatrixXd> mpm::TriangleLMEElement<Tdim>::bmatrix(
     console_->error("{} #{}: {}\n", __FILE__, __LINE__, exception.what());
     return bmatrix;
   }
-
-  // Jacobian dx_i/dxi_j
-  Eigen::Matrix<double, Tdim, Tdim> jacobian =
-      (grad_sf.transpose() * nodal_coordinates);
-
-  // Gradient shapefn of the cell
-  // dN/dx = [J]^-1 * dN/dxi
-  Eigen::MatrixXd grad_shapefn = grad_sf * (jacobian.inverse()).transpose();
 
   for (unsigned i = 0; i < this->nconnectivity_; ++i) {
     Eigen::Matrix<double, 3, Tdim> bi;
@@ -372,24 +364,9 @@ inline Eigen::Matrix<double, Tdim, Tdim>
         const VectorDim& xi, const Eigen::MatrixXd& nodal_coordinates,
         VectorDim& lambda, const MatrixDim& deformation_gradient) const {
 
-  // Get gradient shape functions
-  const Eigen::MatrixXd grad_shapefn =
-      this->grad_shapefn(xi, lambda, deformation_gradient);
-
-  try {
-    // Check if matrices dimensions are correct
-    if ((grad_shapefn.rows() != nodal_coordinates.rows()) ||
-        (xi.size() != nodal_coordinates.cols()))
-      throw std::runtime_error(
-          "Jacobian calculation: Incorrect dimension of xi and "
-          "nodal_coordinates");
-  } catch (std::exception& exception) {
-    console_->error("{} #{}: {}\n", __FILE__, __LINE__, exception.what());
-    return Eigen::Matrix<double, Tdim, Tdim>::Zero();
-  }
-
-  // Jacobian dx_i/dxi_j
-  return (grad_shapefn.transpose() * nodal_coordinates);
+  // Jacobian dx_i/dxi_j local
+  return this->jacobian_local(xi, nodal_coordinates.block(0, 0, 3, 2), lambda,
+                              deformation_gradient);
 }
 
 //! Compute Jacobian local with particle size and deformation gradient

--- a/include/elements/3d/hexahedron_element.tcc
+++ b/include/elements/3d/hexahedron_element.tcc
@@ -271,7 +271,8 @@ inline Eigen::Matrix<double, Tdim, Tdim>
         const Eigen::Matrix<double, 3, 3>& deformation_gradient) const {
   // Get gradient shape functions
   const Eigen::MatrixXd grad_shapefn =
-      this->grad_shapefn(xi, particle_size, deformation_gradient);
+      mpm::HexahedronElement<Tdim, Tnfunctions>::grad_shapefn(
+          xi, particle_size, deformation_gradient);
   try {
     // Check if dimensions are correct
     if ((grad_shapefn.rows() != nodal_coordinates.rows()) ||

--- a/tests/elements/hexahedron_lme_element_test.cc
+++ b/tests/elements/hexahedron_lme_element_test.cc
@@ -1,4 +1,5 @@
 // hexahedron element test
+#include <iostream>
 #include <memory>
 
 #include "catch.hpp"
@@ -462,8 +463,8 @@ TEST_CASE("Hexahedron lme elements are checked", "[hex][element][3D][lme]") {
           Eigen::Matrix<double, Dim, Dim> jacobian;
           // clang-format off
           jacobian << 1., 0., 0.,
-                      0., 1., 0.,
-                      0., 0., 1;
+                      0., 0., 1.,
+                      0., -1., 0.;
           // clang-format on
 
           // Get Jacobian


### PR DESCRIPTION
**Describe the PR**
This PR fixes a bug in two functions: `jacobian` and `bmatrix` in high-order elements other than the GIMP. The former way is incorrect since the bspline and lme shape functions directly compute `dN/dx` not `dN/dxi` like the local shape function or GIMP. The proposed fix is to call the basis element functions.

**Related Issues/PRs**
N/A

**Additional context**
Some minor fix in tests has been also done.
