### PR TITLE
[Bugfix] LME convergence

### DIFF
--- a/include/elements/2d/quadrilateral_lme_element.h
+++ b/include/elements/2d/quadrilateral_lme_element.h
@@ -215,6 +215,8 @@ class QuadrilateralLMEElement : public QuadrilateralElement<2, 4> {
   double support_radius_;
   //! Anisotropy parameter
   bool anisotropy_{false};
+  //! Apply preconditioner
+  bool preconditioner_{false};
   //! Nodal coordinates vector (n_connectivity_ x Tdim)
   Eigen::MatrixXd nodal_coordinates_;
 };

--- a/include/elements/2d/quadrilateral_lme_element.tcc
+++ b/include/elements/2d/quadrilateral_lme_element.tcc
@@ -139,13 +139,19 @@ inline Eigen::VectorXd mpm::QuadrilateralLMEElement<Tdim>::shapefn(
         } else if ((lambda - olambda).norm() < tolerance) {
           convergence = true;
         } else if (it == max_it) {
+          //! Abort simulation if r.norm() is too big
+          if (r.norm() > 1.e-3)
+            throw std::runtime_error(
+                "LME shapefn: the LME Newton-Raphson iteration unable to "
+                "converge");
+
           //! Check condition number
           Eigen::JacobiSVD<Eigen::MatrixXd> svd(J);
           const double rcond =
               svd.singularValues()(svd.singularValues().size() - 1) /
               svd.singularValues()(0);
           if (rcond < 1E-8)
-            console_->warn("The LME Hessian matrix is singular!");
+            console_->warn("LME shapefn: the LME Hessian matrix is singular!");
           convergence = true;
         }
         it++;
@@ -293,13 +299,20 @@ inline Eigen::MatrixXd mpm::QuadrilateralLMEElement<Tdim>::grad_shapefn(
         } else if ((lambda - olambda).norm() < tolerance) {
           convergence = true;
         } else if (it == max_it) {
+          //! Abort simulation if r.norm() is too big
+          if (r.norm() > 1.e-3)
+            throw std::runtime_error(
+                "LME grad_shapefn: the LME Newton-Raphson iteration unable to "
+                "converge");
+
           //! Check condition number
           Eigen::JacobiSVD<Eigen::MatrixXd> svd(J);
           const double rcond =
               svd.singularValues()(svd.singularValues().size() - 1) /
               svd.singularValues()(0);
           if (rcond < 1E-8)
-            console_->warn("The LME Hessian matrix is singular!");
+            console_->warn(
+                "LME grad_shapefn: the LME Hessian matrix is singular!");
           convergence = true;
         }
         it++;

--- a/include/elements/2d/triangle_lme_element.h
+++ b/include/elements/2d/triangle_lme_element.h
@@ -177,6 +177,8 @@ class TriangleLMEElement : public TriangleElement<2, 3> {
   double support_radius_;
   //! Anisotropy parameter
   bool anisotropy_{false};
+  //! Apply preconditioner
+  bool preconditioner_{false};
   //! Nodal coordinates vector (n_connectivity_ x Tdim)
   Eigen::MatrixXd nodal_coordinates_;
 };

--- a/include/elements/2d/triangle_lme_element.tcc
+++ b/include/elements/2d/triangle_lme_element.tcc
@@ -97,10 +97,8 @@ inline Eigen::VectorXd mpm::TriangleLMEElement<Tdim>::shapefn(
                                  (rel_coordinates.col(n)).transpose());
         }
 
-        //! Add preconditioner for J (Mathieu Foca, PhD Thesis)
-        J.diagonal().array() += r.norm();
-
         //! Compute Delta lambda
+        const auto olambda = lambda;
         const auto& dlambda = J.inverse() * (-r);
         lambda = lambda + dlambda;
 
@@ -129,6 +127,8 @@ inline Eigen::VectorXd mpm::TriangleLMEElement<Tdim>::shapefn(
 
         //! Check convergence
         if (r.norm() < tolerance) {
+          convergence = true;
+        } else if ((lambda - olambda).norm() < tolerance) {
           convergence = true;
         } else if (it == max_it) {
           //! Check condition number
@@ -233,9 +233,6 @@ inline Eigen::MatrixXd mpm::TriangleLMEElement<Tdim>::grad_shapefn(
                              (rel_coordinates.col(n)).transpose());
     }
 
-    //! Add preconditioner for J (Mathieu Foca, PhD Thesis)
-    J.diagonal().array() += r.norm();
-
     //! Begin Newton-Raphson iteration
     const double tolerance = 1.e-12;
     if (r.norm() > tolerance) {
@@ -244,6 +241,7 @@ inline Eigen::MatrixXd mpm::TriangleLMEElement<Tdim>::grad_shapefn(
       unsigned max_it = 10;
       while (!convergence) {
         //! Compute Delta lambda
+        const auto olambda = lambda;
         const auto& dlambda = J.inverse() * (-r);
         lambda = lambda + dlambda;
 
@@ -277,11 +275,21 @@ inline Eigen::MatrixXd mpm::TriangleLMEElement<Tdim>::grad_shapefn(
                                  (rel_coordinates.col(n)).transpose());
         }
 
-        //! Add preconditioner for J (Mathieu Foca, PhD Thesis)
-        J.diagonal().array() += r.norm();
-
         //! Check convergence
-        if (r.norm() <= tolerance || it == max_it) convergence = true;
+        if (r.norm() < tolerance) {
+          convergence = true;
+        } else if ((lambda - olambda).norm() < tolerance) {
+          convergence = true;
+        } else if (it == max_it) {
+          //! Check condition number
+          Eigen::JacobiSVD<Eigen::MatrixXd> svd(J);
+          const double rcond =
+              svd.singularValues()(svd.singularValues().size() - 1) /
+              svd.singularValues()(0);
+          if (rcond < 1E-8)
+            console_->warn("The LME Hessian matrix is singular!");
+          convergence = true;
+        }
         it++;
       }
     }

--- a/include/elements/2d/triangle_lme_element.tcc
+++ b/include/elements/2d/triangle_lme_element.tcc
@@ -140,14 +140,19 @@ inline Eigen::VectorXd mpm::TriangleLMEElement<Tdim>::shapefn(
         } else if ((lambda - olambda).norm() < tolerance) {
           convergence = true;
         } else if (it == max_it) {
+          //! Abort simulation if r.norm() is too big
+          if (r.norm() > 1.e-3)
+            throw std::runtime_error(
+                "LME shapefn: the LME Newton-Raphson iteration unable to "
+                "converge");
+
           //! Check condition number
           Eigen::JacobiSVD<Eigen::MatrixXd> svd(J);
           const double rcond =
               svd.singularValues()(svd.singularValues().size() - 1) /
               svd.singularValues()(0);
           if (rcond < 1E-8)
-            console_->warn("The LME Hessian matrix is singular!");
-
+            console_->warn("LME shapefn: the LME Hessian matrix is singular!");
           convergence = true;
         }
         it++;
@@ -296,13 +301,20 @@ inline Eigen::MatrixXd mpm::TriangleLMEElement<Tdim>::grad_shapefn(
         } else if ((lambda - olambda).norm() < tolerance) {
           convergence = true;
         } else if (it == max_it) {
+          //! Abort simulation if r.norm() is too big
+          if (r.norm() > 1.e-3)
+            throw std::runtime_error(
+                "LME grad_shapefn: the LME Newton-Raphson iteration unable to "
+                "converge");
+
           //! Check condition number
           Eigen::JacobiSVD<Eigen::MatrixXd> svd(J);
           const double rcond =
               svd.singularValues()(svd.singularValues().size() - 1) /
               svd.singularValues()(0);
           if (rcond < 1E-8)
-            console_->warn("The LME Hessian matrix is singular!");
+            console_->warn(
+                "LME grad_shapefn: the LME Hessian matrix is singular!");
           convergence = true;
         }
         it++;

--- a/include/elements/2d/triangle_lme_element.tcc
+++ b/include/elements/2d/triangle_lme_element.tcc
@@ -8,6 +8,12 @@ void mpm::TriangleLMEElement<Tdim>::initialise_lme_connectivity_properties(
   this->beta_ = beta;
   this->anisotropy_ = anisotropy;
   this->support_radius_ = radius;
+
+  //! Uniform spacing length in 2D
+  const double spacing_length =
+      std::abs(nodal_coordinates(1, 0) - nodal_coordinates(0, 0));
+  const double gamma = beta * spacing_length * spacing_length;
+  if (gamma > 6.0) this->preconditioner_ = true;
 }
 
 //! Return shape functions of a Quadrilateral LME Element at a given
@@ -88,7 +94,7 @@ inline Eigen::VectorXd mpm::TriangleLMEElement<Tdim>::shapefn(
     if (r.norm() > tolerance) {
       bool convergence = false;
       unsigned it = 1;
-      const unsigned max_it = 10;
+      const unsigned max_it = 100;
       while (!convergence) {
         //! Compute matrix J
         Eigen::Matrix2d J = -r * r.transpose();
@@ -96,6 +102,9 @@ inline Eigen::VectorXd mpm::TriangleLMEElement<Tdim>::shapefn(
           J.noalias() += p(n) * ((rel_coordinates.col(n)) *
                                  (rel_coordinates.col(n)).transpose());
         }
+
+        //! Add preconditioner for J (Mathieu Foca, PhD Thesis)
+        if (this->preconditioner_) J.diagonal().array() += r.norm();
 
         //! Compute Delta lambda
         const auto olambda = lambda;
@@ -233,12 +242,15 @@ inline Eigen::MatrixXd mpm::TriangleLMEElement<Tdim>::grad_shapefn(
                              (rel_coordinates.col(n)).transpose());
     }
 
+    //! Add preconditioner for J (Mathieu Foca, PhD Thesis)
+    if (this->preconditioner_) J.diagonal().array() += r.norm();
+
     //! Begin Newton-Raphson iteration
     const double tolerance = 1.e-12;
     if (r.norm() > tolerance) {
       bool convergence = false;
       unsigned it = 1;
-      unsigned max_it = 10;
+      unsigned max_it = 100;
       while (!convergence) {
         //! Compute Delta lambda
         const auto olambda = lambda;
@@ -274,6 +286,9 @@ inline Eigen::MatrixXd mpm::TriangleLMEElement<Tdim>::grad_shapefn(
           J.noalias() += p(n) * ((rel_coordinates.col(n)) *
                                  (rel_coordinates.col(n)).transpose());
         }
+
+        //! Add preconditioner for J (Mathieu Foca, PhD Thesis)
+        if (this->preconditioner_) J.diagonal().array() += r.norm();
 
         //! Check convergence
         if (r.norm() < tolerance) {

--- a/include/elements/3d/hexahedron_lme_element.h
+++ b/include/elements/3d/hexahedron_lme_element.h
@@ -135,6 +135,8 @@ class HexahedronLMEElement : public HexahedronElement<3, 8> {
   double support_radius_;
   //! Anisotropy parameter
   bool anisotropy_{false};
+  //! Apply preconditioner
+  bool preconditioner_{false};
   //! Nodal coordinates vector (n_connectivity_ x Tdim)
   Eigen::MatrixXd nodal_coordinates_;
 };

--- a/include/elements/3d/hexahedron_lme_element.tcc
+++ b/include/elements/3d/hexahedron_lme_element.tcc
@@ -140,14 +140,19 @@ inline Eigen::VectorXd mpm::HexahedronLMEElement<Tdim>::shapefn(
         } else if ((lambda - olambda).norm() < tolerance) {
           convergence = true;
         } else if (it == max_it) {
+          //! Abort simulation if r.norm() is too big
+          if (r.norm() > 1.e-3)
+            throw std::runtime_error(
+                "LME shapefn: the LME Newton-Raphson iteration unable to "
+                "converge");
+
           //! Check condition number
           Eigen::JacobiSVD<Eigen::MatrixXd> svd(J);
           const double rcond =
               svd.singularValues()(svd.singularValues().size() - 1) /
               svd.singularValues()(0);
           if (rcond < 1E-8)
-            console_->warn("The LME Hessian matrix is singular!");
-
+            console_->warn("LME shapefn: the LME Hessian matrix is singular!");
           convergence = true;
         }
         it++;
@@ -296,13 +301,20 @@ inline Eigen::MatrixXd mpm::HexahedronLMEElement<Tdim>::grad_shapefn(
         } else if ((lambda - olambda).norm() < tolerance) {
           convergence = true;
         } else if (it == max_it) {
+          //! Abort simulation if r.norm() is too big
+          if (r.norm() > 1.e-3)
+            throw std::runtime_error(
+                "LME grad_shapefn: the LME Newton-Raphson iteration unable to "
+                "converge");
+
           //! Check condition number
           Eigen::JacobiSVD<Eigen::MatrixXd> svd(J);
           const double rcond =
               svd.singularValues()(svd.singularValues().size() - 1) /
               svd.singularValues()(0);
           if (rcond < 1E-8)
-            console_->warn("The LME Hessian matrix is singular!");
+            console_->warn(
+                "LME grad_shapefn: the LME Hessian matrix is singular!");
           convergence = true;
         }
         it++;

--- a/include/elements/3d/hexahedron_lme_element.tcc
+++ b/include/elements/3d/hexahedron_lme_element.tcc
@@ -97,10 +97,8 @@ inline Eigen::VectorXd mpm::HexahedronLMEElement<Tdim>::shapefn(
                                  (rel_coordinates.col(n)).transpose());
         }
 
-        //! Add preconditioner for J (Mathieu Foca, PhD Thesis)
-        J.diagonal().array() += r.norm();
-
         //! Compute Delta lambda
+        const auto olambda = lambda;
         const auto& dlambda = J.inverse() * (-r);
         lambda = lambda + dlambda;
 
@@ -129,6 +127,8 @@ inline Eigen::VectorXd mpm::HexahedronLMEElement<Tdim>::shapefn(
 
         //! Check convergence
         if (r.norm() < tolerance) {
+          convergence = true;
+        } else if ((lambda - olambda).norm() < tolerance) {
           convergence = true;
         } else if (it == max_it) {
           //! Check condition number
@@ -233,9 +233,6 @@ inline Eigen::MatrixXd mpm::HexahedronLMEElement<Tdim>::grad_shapefn(
                              (rel_coordinates.col(n)).transpose());
     }
 
-    //! Add preconditioner for J (Mathieu Foca, PhD Thesis)
-    J.diagonal().array() += r.norm();
-
     //! Begin Newton-Raphson iteration
     const double tolerance = 1.e-12;
     if (r.norm() > tolerance) {
@@ -244,6 +241,7 @@ inline Eigen::MatrixXd mpm::HexahedronLMEElement<Tdim>::grad_shapefn(
       unsigned max_it = 10;
       while (!convergence) {
         //! Compute Delta lambda
+        const auto olambda = lambda;
         const auto& dlambda = J.inverse() * (-r);
         lambda = lambda + dlambda;
 
@@ -277,11 +275,21 @@ inline Eigen::MatrixXd mpm::HexahedronLMEElement<Tdim>::grad_shapefn(
                                  (rel_coordinates.col(n)).transpose());
         }
 
-        //! Add preconditioner for J (Mathieu Foca, PhD Thesis)
-        J.diagonal().array() += r.norm();
-
         //! Check convergence
-        if (r.norm() <= tolerance || it == max_it) convergence = true;
+        if (r.norm() < tolerance) {
+          convergence = true;
+        } else if ((lambda - olambda).norm() < tolerance) {
+          convergence = true;
+        } else if (it == max_it) {
+          //! Check condition number
+          Eigen::JacobiSVD<Eigen::MatrixXd> svd(J);
+          const double rcond =
+              svd.singularValues()(svd.singularValues().size() - 1) /
+              svd.singularValues()(0);
+          if (rcond < 1E-8)
+            console_->warn("The LME Hessian matrix is singular!");
+          convergence = true;
+        }
         it++;
       }
     }


### PR DESCRIPTION
**Describe the PR**
This PR fixes an issue with LME convergence at a lower gamma value. The preconditioner added following Mathieu Foca causes the Newton-Raphson loop in LME elements to converge slower than expected, especially for gamma less than 6.0. For gamma larger than 6.0, the preconditioner is proven to be helpful to guarantee convergence, even with a slower rate. In order to accommodate the above, I propose adding an additional boolean that is going to tell whether a preconditioner should be applied or not.

**Related Issues/PRs**
N/A

**Additional context**
N/A