### PR TITLE
[Bugfix] Initialization of kinematics BC in Implicit solver

### DIFF
--- a/include/nodes/node.h
+++ b/include/nodes/node.h
@@ -384,6 +384,10 @@ class Node : public NodeBase<Tdim> {
       const unsigned dir, const double displacement,
       const std::shared_ptr<FunctionBase>& function) override;
 
+  //! Apply displacement constraints
+  //! \ingroup Implicit
+  void apply_displacement_constraints() override;
+
   //! Return displacement constraint
   //! \ingroup Implicit
   double displacement_constraint(const unsigned dir,

--- a/include/nodes/node.tcc
+++ b/include/nodes/node.tcc
@@ -1086,31 +1086,3 @@ void mpm::Node<Tdim, Tdof, Tnphases>::initialise_nonlocal_node() noexcept {
   nonlocal_node_type_.resize(Tdim);
   std::fill(nonlocal_node_type_.begin(), nonlocal_node_type_.end(), 0);
 }
-
-//! Assign displacement constraints
-template <unsigned Tdim, unsigned Tdof, unsigned Tnphases>
-bool mpm::Node<Tdim, Tdof, Tnphases>::assign_displacement_constraint(
-    const unsigned dir, const double displacement,
-    const std::shared_ptr<FunctionBase>& function) {
-  bool status = true;
-  try {
-    //! Constrain directions can take values between 0 and Dim * Nphases
-    if (dir < (Tdim * Tnphases))
-      this->displacement_constraints_.insert(std::make_pair<unsigned, double>(
-          static_cast<unsigned>(dir), static_cast<double>(displacement)));
-    else
-      throw std::runtime_error("Constraint direction is out of bounds");
-
-    // Assign displacement function
-    if (function != nullptr)
-      this->displacement_function_.insert(
-          std::make_pair<unsigned, std::shared_ptr<FunctionBase>>(
-              static_cast<unsigned>(dir),
-              static_cast<std::shared_ptr<FunctionBase>>(function)));
-
-  } catch (std::exception& exception) {
-    console_->error("{} #{}: {}\n", __FILE__, __LINE__, exception.what());
-    status = false;
-  }
-  return status;
-}

--- a/include/nodes/node_base.h
+++ b/include/nodes/node_base.h
@@ -380,6 +380,10 @@ class NodeBase {
       const unsigned dir, const double displacement,
       const std::shared_ptr<FunctionBase>& function) = 0;
 
+  //! Apply displacement constraints
+  //! \ingroup Implicit
+  virtual void apply_displacement_constraints() = 0;
+
   //! Return displacement constraint
   //! \ingroup Implicit
   virtual double displacement_constraint(const unsigned dir,

--- a/tests/nodes/node_implicit_test.cc
+++ b/tests/nodes/node_implicit_test.cc
@@ -328,6 +328,38 @@ TEST_CASE("Implicit Node is checked for 2D case", "[node][2D][Implicit]") {
       REQUIRE(node->velocity(Nphase)(i) == Approx(0.1).epsilon(Tolerance));
     for (unsigned i = 0; i < Dim; ++i)
       REQUIRE(node->acceleration(Nphase)(i) == Approx(0.1).epsilon(Tolerance));
+
+    SECTION("Check Cartesian displacement constraints") {
+      // Assign displacement constraints
+      REQUIRE(node->assign_displacement_constraint(0, -12.5, nullptr) == true);
+      // Check out of bounds condition
+      REQUIRE(node->assign_displacement_constraint(2, 0., nullptr) == false);
+
+      // Apply constraints
+      node->apply_displacement_constraints();
+
+      // Check apply constraints
+      Eigen::VectorXd displacement;
+      displacement.resize(Dim);
+      displacement << -12.5, 0.0;
+      for (unsigned i = 0; i < displacement.size(); ++i)
+        REQUIRE(node->displacement(Nphase)(i) ==
+                Approx(displacement(i)).epsilon(Tolerance));
+
+      Eigen::VectorXd velocity;
+      velocity.resize(Dim);
+      velocity << 0.0, 0.1;
+      for (unsigned i = 0; i < velocity.size(); ++i)
+        REQUIRE(node->velocity(Nphase)(i) ==
+                Approx(velocity(i)).epsilon(Tolerance));
+
+      Eigen::VectorXd acceleration;
+      acceleration.resize(Dim);
+      acceleration << 0., 0.1;
+      for (unsigned i = 0; i < acceleration.size(); ++i)
+        REQUIRE(node->acceleration(Nphase)(i) ==
+                Approx(acceleration(i)).epsilon(Tolerance));
+    }
   }
 }
 
@@ -494,5 +526,38 @@ TEST_CASE("Implicit Node is checked for 3D case", "[node][3D][Implicit]") {
       REQUIRE(node->velocity(Nphase)(i) == Approx(0.1).epsilon(Tolerance));
     for (unsigned i = 0; i < Dim; ++i)
       REQUIRE(node->acceleration(Nphase)(i) == Approx(0.1).epsilon(Tolerance));
+
+    SECTION("Check Cartesian displacement constraints") {
+      // Apply displacement constraints
+      REQUIRE(node->assign_displacement_constraint(0, 10.5, nullptr) == true);
+      REQUIRE(node->assign_displacement_constraint(1, -12.5, nullptr) == true);
+      // Check out of bounds condition
+      REQUIRE(node->assign_displacement_constraint(4, 0., nullptr) == false);
+
+      // Apply constraints
+      node->apply_displacement_constraints();
+
+      // Check apply constraints
+      Eigen::VectorXd displacement;
+      displacement.resize(Dim);
+      displacement << 10.5, -12.5, 0.0;
+      for (unsigned i = 0; i < displacement.size(); ++i)
+        REQUIRE(node->displacement(Nphase)(i) ==
+                Approx(displacement(i)).epsilon(Tolerance));
+
+      Eigen::VectorXd velocity;
+      velocity.resize(Dim);
+      velocity << 0.0, 0.0, 0.1;
+      for (unsigned i = 0; i < velocity.size(); ++i)
+        REQUIRE(node->velocity(Nphase)(i) ==
+                Approx(velocity(i)).epsilon(Tolerance));
+
+      Eigen::VectorXd acceleration;
+      acceleration.resize(Dim);
+      acceleration << 0.0, 0.0, 0.1;
+      for (unsigned i = 0; i < acceleration.size(); ++i)
+        REQUIRE(node->acceleration(Nphase)(i) ==
+                Approx(acceleration(i)).epsilon(Tolerance));
+    }
   }
 }


### PR DESCRIPTION
**Describe the PR**
There is a bug in the current code that the boundary condition is not imposed in initializing the velocity and acceleration in nodes. The current PR fixes that bug by adding a new function `apply_displacement_constraints()` in `compute_velocity_acceleration()`.

**Related Issues/PRs**
N/A

**Additional context**
I also moved `assign_displacement_constraint` function to `node_implicit.tcc`
