### PR TITLE
Stress rate

### DIFF
--- a/include/data_structures/data_types.h
+++ b/include/data_structures/data_types.h
@@ -41,6 +41,11 @@ inline double zero() {
 //! Face: Nodes on boundary faces
 enum class Position { None, Corner, Edge, Face };
 
+//! Stress rate type
+//! None: Cauchy rate (non-objective)
+//! Jaumann: Jaumann rate of Cauchy stress tensor (objective)
+enum class StressRate { None, Jaumann };
+
 //! Velocity update type
 //! Flip: fluid-implicit-particle (acceleration update)
 //! Pic: particle-in-cell (velocity update)

--- a/include/particles/particle.h
+++ b/include/particles/particle.h
@@ -198,7 +198,10 @@ class Particle : public ParticleBase<Tdim> {
   }
 
   //! Compute stress
-  void compute_stress(double dt) noexcept override;
+  //! \param[in] dt Analysis time step
+  //! \param[in] stress_rate Use Cauchy or Jaumann rate of stress
+  void compute_stress(double dt, mpm::StressRate stress_rate =
+                                     mpm::StressRate::None) noexcept override;
 
   //! Return stress of the particle
   Eigen::Matrix<double, 6, 1> stress() const override { return stress_; }

--- a/include/particles/particle.h
+++ b/include/particles/particle.h
@@ -9,6 +9,7 @@
 
 #include "cell.h"
 #include "logger.h"
+#include "math_utility.h"
 #include "particle_base.h"
 
 namespace mpm {

--- a/include/particles/particle.h
+++ b/include/particles/particle.h
@@ -198,7 +198,7 @@ class Particle : public ParticleBase<Tdim> {
   }
 
   //! Compute stress
-  void compute_stress() noexcept override;
+  void compute_stress(double dt) noexcept override;
 
   //! Return stress of the particle
   Eigen::Matrix<double, 6, 1> stress() const override { return stress_; }

--- a/include/particles/particle.tcc
+++ b/include/particles/particle.tcc
@@ -872,7 +872,7 @@ void mpm::Particle<Tdim>::compute_strain(double dt) noexcept {
 
 // Compute stress
 template <unsigned Tdim>
-void mpm::Particle<Tdim>::compute_stress() noexcept {
+void mpm::Particle<Tdim>::compute_stress(double dt) noexcept {
   // Check if material ptr is valid
   assert(this->material() != nullptr);
   // Calculate stress

--- a/include/particles/particle.tcc
+++ b/include/particles/particle.tcc
@@ -878,7 +878,7 @@ void mpm::Particle<Tdim>::compute_stress(double dt,
   assert(this->material() != nullptr);
 
   // Compute material part of stress
-  const Eigen::Matrix<double, 6, 1> material_part_Voigt =
+  const Eigen::Matrix<double, 6, 1>& material_part_voigt =
       (this->material())
           ->compute_stress(stress_, dstrain_, this,
                            &state_variables_[mpm::ParticlePhase::Solid]);
@@ -886,45 +886,33 @@ void mpm::Particle<Tdim>::compute_stress(double dt,
   switch (stress_rate) {
     case mpm::StressRate::None:
       // Update stress
-      this->stress_ = material_part_Voigt;
+      this->stress_ = material_part_voigt;
       break;
 
     case mpm::StressRate::Jaumann:
       // Velocity gradient (dv_i/dx_j)
-      const Eigen::Matrix<double, Tdim, Tdim> L =
+      const Eigen::Matrix<double, Tdim, Tdim>& vel_grad =
           this->compute_velocity_gradient(this->dn_dx_,
                                           mpm::ParticlePhase::SinglePhase);
 
       // Compute spin tensor increment
-      const Eigen::Matrix<double, Tdim, Tdim> W_dt =
-          0.5 * (L - L.transpose()) * dt;
+      const Eigen::Matrix<double, Tdim, Tdim>& spin_dt =
+          0.5 * (vel_grad - vel_grad.transpose()) * dt;
 
       // Convert Cauchy stress from Voigt -> matrix
       const Eigen::Matrix<double, Tdim, Tdim>& stress_matrix =
           mpm::math::matrix_form<Tdim>(this->stress_);
 
       // Compute rotation part of stress increment
-      const Eigen::Matrix<double, Tdim, Tdim> rotation_part_matrix =
-          (W_dt * stress_matrix) - (stress_matrix * W_dt);
+      const Eigen::Matrix<double, Tdim, Tdim>& rotation_part_matrix =
+          (spin_dt * stress_matrix) - (stress_matrix * spin_dt);
 
       // Convert matrix to Voigt (must be 6x1 regardless of Tdim)
-      Eigen::Matrix<double, 6, 1> rotation_part_Voigt;
-
-      rotation_part_Voigt(0) = rotation_part_matrix(0, 0);
-      rotation_part_Voigt(1) = rotation_part_matrix(1, 1);
-      rotation_part_Voigt(2) = 0.;
-      rotation_part_Voigt(3) = rotation_part_matrix(0, 1);
-      rotation_part_Voigt(4) = 0.;
-      rotation_part_Voigt(5) = 0.;
-
-      if (Tdim == 3) {
-        rotation_part_Voigt(2) = rotation_part_matrix(2, 2);
-        rotation_part_Voigt(4) = rotation_part_matrix(1, 2);
-        rotation_part_Voigt(5) = rotation_part_matrix(0, 2);
-      }
+      const Eigen::Matrix<double, 6, 1>& rotation_part_voigt =
+          mpm::math::voigt_form<Tdim>(rotation_part_matrix);
 
       // Update stress
-      this->stress_ = material_part_Voigt + rotation_part_Voigt;
+      this->stress_ = material_part_voigt + rotation_part_voigt;
       break;
   }
 }

--- a/include/particles/particle.tcc
+++ b/include/particles/particle.tcc
@@ -872,7 +872,8 @@ void mpm::Particle<Tdim>::compute_strain(double dt) noexcept {
 
 // Compute stress
 template <unsigned Tdim>
-void mpm::Particle<Tdim>::compute_stress(double dt) noexcept {
+void mpm::Particle<Tdim>::compute_stress(double dt,
+                                         mpm::StressRate stress_rate) noexcept {
   // Check if material ptr is valid
   assert(this->material() != nullptr);
   // Calculate stress

--- a/include/particles/particle_base.h
+++ b/include/particles/particle_base.h
@@ -230,6 +230,7 @@ class ParticleBase {
   virtual double pressure(unsigned phase = mpm::ParticlePhase::Solid) const = 0;
 
   //! Compute strain
+  //! \param[in] dt Analysis time step
   virtual void compute_strain(double dt) noexcept = 0;
 
   //! Strain
@@ -252,7 +253,11 @@ class ParticleBase {
   virtual void initial_stress(const Eigen::Matrix<double, 6, 1>& stress) = 0;
 
   //! Compute stress
-  virtual void compute_stress(double dt) noexcept = 0;
+  //! \param[in] dt Analysis time step
+  //! \param[in] stress_rate Use Cauchy or Jaumann rate of stress
+  virtual void compute_stress(
+      double dt,
+      mpm::StressRate stress_rate = mpm::StressRate::None) noexcept = 0;
 
   //! Return stress
   virtual Eigen::Matrix<double, 6, 1> stress() const = 0;

--- a/include/particles/particle_base.h
+++ b/include/particles/particle_base.h
@@ -252,7 +252,7 @@ class ParticleBase {
   virtual void initial_stress(const Eigen::Matrix<double, 6, 1>& stress) = 0;
 
   //! Compute stress
-  virtual void compute_stress() noexcept = 0;
+  virtual void compute_stress(double dt) noexcept = 0;
 
   //! Return stress
   virtual Eigen::Matrix<double, 6, 1> stress() const = 0;

--- a/include/particles/particle_finite_strain.h
+++ b/include/particles/particle_finite_strain.h
@@ -74,10 +74,14 @@ class ParticleFiniteStrain : public mpm::Particle<Tdim> {
                                    double dt) noexcept override{};
 
   //! Compute deformation gradient increment using nodal velocity
+  //! \param[in] dt Analysis time step
   void compute_strain(double dt) noexcept override;
 
   //! Compute stress and update deformation gradient
-  void compute_stress(double dt) noexcept override;
+  //! \param[in] dt Analysis time step
+  //! \param[in] stress_rate Use Cauchy or Jaumann rate of stress
+  void compute_stress(double dt, mpm::StressRate stress_rate =
+                                     mpm::StressRate::None) noexcept override;
 
   /**
    * \defgroup Implicit Functions dealing with implicit MPM

--- a/include/particles/particle_finite_strain.h
+++ b/include/particles/particle_finite_strain.h
@@ -77,7 +77,7 @@ class ParticleFiniteStrain : public mpm::Particle<Tdim> {
   void compute_strain(double dt) noexcept override;
 
   //! Compute stress and update deformation gradient
-  void compute_stress() noexcept override;
+  void compute_stress(double dt) noexcept override;
 
   /**
    * \defgroup Implicit Functions dealing with implicit MPM

--- a/include/particles/particle_finite_strain.tcc
+++ b/include/particles/particle_finite_strain.tcc
@@ -30,7 +30,7 @@ void mpm::ParticleFiniteStrain<Tdim>::compute_shapefn() noexcept {
 
 // Compute stress
 template <unsigned Tdim>
-void mpm::ParticleFiniteStrain<Tdim>::compute_stress() noexcept {
+void mpm::ParticleFiniteStrain<Tdim>::compute_stress(double dt) noexcept {
   // Check if material ptr is valid
   assert(this->material() != nullptr);
   // Calculate stress

--- a/include/particles/particle_finite_strain.tcc
+++ b/include/particles/particle_finite_strain.tcc
@@ -30,7 +30,8 @@ void mpm::ParticleFiniteStrain<Tdim>::compute_shapefn() noexcept {
 
 // Compute stress
 template <unsigned Tdim>
-void mpm::ParticleFiniteStrain<Tdim>::compute_stress(double dt) noexcept {
+void mpm::ParticleFiniteStrain<Tdim>::compute_stress(
+    double dt, mpm::StressRate stress_rate) noexcept {
   // Check if material ptr is valid
   assert(this->material() != nullptr);
   // Calculate stress

--- a/include/particles/particle_fluid.h
+++ b/include/particles/particle_fluid.h
@@ -36,7 +36,7 @@ class FluidParticle : public mpm::Particle<Tdim> {
   FluidParticle& operator=(const FluidParticle<Tdim>&) = delete;
 
   //! Compute stress
-  void compute_stress() noexcept override;
+  void compute_stress(double dt) noexcept override;
 
   //! Map internal force
   inline void map_internal_force() noexcept override;

--- a/include/particles/particle_fluid.h
+++ b/include/particles/particle_fluid.h
@@ -36,7 +36,10 @@ class FluidParticle : public mpm::Particle<Tdim> {
   FluidParticle& operator=(const FluidParticle<Tdim>&) = delete;
 
   //! Compute stress
-  void compute_stress(double dt) noexcept override;
+  //! \param[in] dt Analysis time step
+  //! \param[in] stress_rate Use Cauchy or Jaumann rate of stress
+  void compute_stress(double dt, mpm::StressRate stress_rate =
+                                     mpm::StressRate::None) noexcept override;
 
   //! Map internal force
   inline void map_internal_force() noexcept override;

--- a/include/particles/particle_fluid.tcc
+++ b/include/particles/particle_fluid.tcc
@@ -11,7 +11,8 @@ mpm::FluidParticle<Tdim>::FluidParticle(Index id, const VectorDim& coord)
 
 // Compute stress
 template <unsigned Tdim>
-void mpm::FluidParticle<Tdim>::compute_stress(double dt) noexcept {
+void mpm::FluidParticle<Tdim>::compute_stress(
+    double dt, mpm::StressRate stress_rate) noexcept {
   // Run particle compute stress
   mpm::Particle<Tdim>::compute_stress(dt);
 

--- a/include/particles/particle_fluid.tcc
+++ b/include/particles/particle_fluid.tcc
@@ -11,9 +11,9 @@ mpm::FluidParticle<Tdim>::FluidParticle(Index id, const VectorDim& coord)
 
 // Compute stress
 template <unsigned Tdim>
-void mpm::FluidParticle<Tdim>::compute_stress() noexcept {
+void mpm::FluidParticle<Tdim>::compute_stress(double dt) noexcept {
   // Run particle compute stress
-  mpm::Particle<Tdim>::compute_stress();
+  mpm::Particle<Tdim>::compute_stress(dt);
 
   // Calculate fluid turbulent stress
   this->stress_.noalias() += this->compute_turbulent_stress();

--- a/include/solvers/mpm_base.h
+++ b/include/solvers/mpm_base.h
@@ -254,6 +254,8 @@ class MPMBase : public MPM {
   //! Logger
   using mpm::MPM::console_;
 
+  //! State rate method
+  mpm::StressRate stress_rate_{mpm::StressRate::None};
   //! Stress update method
   std::string stress_update_{"usf"};
   //! Stress update scheme

--- a/include/solvers/mpm_base.tcc
+++ b/include/solvers/mpm_base.tcc
@@ -58,7 +58,8 @@ mpm::MPMBase<Tdim>::MPMBase(const std::shared_ptr<IO>& io) : mpm::MPM(io) {
           stress_rate_ = mpm::StressRate::Jaumann;
         else
           throw std::runtime_error("Stress rate type is not supported");
-      }
+      } else
+        throw std::runtime_error("No stress rate type specified");
     } catch (std::exception& exception) {
       console_->warn(
           "{} #{}: {}. Using Cauchy stress rate (non-objective) as default",

--- a/include/solvers/mpm_base.tcc
+++ b/include/solvers/mpm_base.tcc
@@ -56,11 +56,12 @@ mpm::MPMBase<Tdim>::MPMBase(const std::shared_ptr<IO>& io) : mpm::MPM(io) {
       if (analysis_.find("stress_rate") != analysis_.end()) {
         if (analysis_["stress_rate"].template get<std::string>() == "jaumann")
           stress_rate_ = mpm::StressRate::Jaumann;
+        else
+          throw std::runtime_error("Stress rate type is not supported");
       }
     } catch (std::exception& exception) {
       console_->warn(
-          "{} #{}: {}. Stress rate method is not specified, using Cauchy "
-          "stress rate (non-objective) as default",
+          "{} #{}: {}. Using Cauchy stress rate (non-objective) as default",
           __FILE__, __LINE__, exception.what());
     }
 

--- a/include/solvers/mpm_base.tcc
+++ b/include/solvers/mpm_base.tcc
@@ -51,6 +51,19 @@ mpm::MPMBase<Tdim>::MPMBase(const std::shared_ptr<IO>& io) : mpm::MPM(io) {
     if (analysis_.find("locate_particles") != analysis_.end())
       locate_particles_ = analysis_["locate_particles"].template get<bool>();
 
+    // Stress rate method (None/Jaumann)
+    try {
+      if (analysis_.find("stress_rate") != analysis_.end()) {
+        if (analysis_["stress_rate"].template get<std::string>() == "jaumann")
+          stress_rate_ = mpm::StressRate::Jaumann;
+      }
+    } catch (std::exception& exception) {
+      console_->warn(
+          "{} #{}: {}. Stress rate method is not specified, using Cauchy "
+          "stress rate (non-objective) as default",
+          __FILE__, __LINE__, exception.what());
+    }
+
     // Stress update method (USF/USL/MUSL/Newmark)
     try {
       if (analysis_.find("mpm_scheme") != analysis_.end())

--- a/include/solvers/mpm_explicit.h
+++ b/include/solvers/mpm_explicit.h
@@ -55,6 +55,8 @@ class MPMExplicit : public MPMBase<Tdim> {
   using mpm::MPMBase<Tdim>::graph_;
 #endif
 
+  //! Stress rate method
+  using mpm::MPMBase<Tdim>::stress_rate_;
   //! velocity update
   using mpm::MPMBase<Tdim>::velocity_update_;
   //! FLIP-PIC blending ratio

--- a/include/solvers/mpm_explicit.tcc
+++ b/include/solvers/mpm_explicit.tcc
@@ -137,7 +137,8 @@ bool mpm::MPMExplicit<Tdim>::solve() {
     contact_->compute_contact_forces();
 
     // Update stress first
-    mpm_scheme_->precompute_stress_strain(phase, pressure_smoothing_);
+    mpm_scheme_->precompute_stress_strain(phase, pressure_smoothing_,
+                                          stress_rate_);
 
     // Compute forces
     mpm_scheme_->compute_forces(gravity_, phase, step_,
@@ -158,7 +159,8 @@ bool mpm::MPMExplicit<Tdim>::solve() {
     mpm_scheme_->postcompute_nodal_kinematics(velocity_update_, phase);
 
     // Update Stress Last
-    mpm_scheme_->postcompute_stress_strain(phase, pressure_smoothing_);
+    mpm_scheme_->postcompute_stress_strain(phase, pressure_smoothing_,
+                                           stress_rate_);
 
     // Locate particles
     mpm_scheme_->locate_particles(this->locate_particles_);

--- a/include/solvers/mpm_explicit_twophase.tcc
+++ b/include/solvers/mpm_explicit_twophase.tcc
@@ -17,8 +17,9 @@ void mpm::MPMExplicitTwoPhase<Tdim>::compute_stress_strain() {
   mesh_->iterate_over_particles(std::bind(
       &mpm::ParticleBase<Tdim>::update_volume, std::placeholders::_1));
   // Iterate over each particle to compute stress of soil skeleton
-  mesh_->iterate_over_particles(std::bind(
-      &mpm::ParticleBase<Tdim>::compute_stress, std::placeholders::_1, dt_));
+  mesh_->iterate_over_particles(
+      std::bind(&mpm::ParticleBase<Tdim>::compute_stress, std::placeholders::_1,
+                dt_, mpm::StressRate::None));
   // Pressure smoothing
   if (pressure_smoothing_) this->pressure_smoothing(mpm::ParticlePhase::Solid);
 

--- a/include/solvers/mpm_explicit_twophase.tcc
+++ b/include/solvers/mpm_explicit_twophase.tcc
@@ -18,7 +18,7 @@ void mpm::MPMExplicitTwoPhase<Tdim>::compute_stress_strain() {
       &mpm::ParticleBase<Tdim>::update_volume, std::placeholders::_1));
   // Iterate over each particle to compute stress of soil skeleton
   mesh_->iterate_over_particles(std::bind(
-      &mpm::ParticleBase<Tdim>::compute_stress, std::placeholders::_1));
+      &mpm::ParticleBase<Tdim>::compute_stress, std::placeholders::_1, dt_));
   // Pressure smoothing
   if (pressure_smoothing_) this->pressure_smoothing(mpm::ParticlePhase::Solid);
 

--- a/include/solvers/mpm_implicit.tcc
+++ b/include/solvers/mpm_implicit.tcc
@@ -217,7 +217,8 @@ bool mpm::MPMImplicit<Tdim>::solve() {
                                                    newmark_gamma_);
 
       // Update stress and strain
-      mpm_scheme_->postcompute_stress_strain(phase_, pressure_smoothing_);
+      mpm_scheme_->postcompute_stress_strain(phase_, pressure_smoothing_,
+                                             mpm::StressRate::None);
 
       // Check convergence of Newton-Raphson iteration
       if (nonlinear_) {

--- a/include/solvers/mpm_scheme/mpm_scheme.h
+++ b/include/solvers/mpm_scheme/mpm_scheme.h
@@ -31,19 +31,23 @@ class MPMScheme {
   //! \param[in] phase Phase to smooth pressure
   //! \param[in] pressure_smoothing Enable or disable pressure smoothing
   virtual inline void compute_stress_strain(unsigned phase,
-                                            bool pressure_smoothing);
+                                            bool pressure_smoothing,
+                                            mpm::StressRate stress_rate);
 
   //! Precompute stress and strain (empty call)
   //! \param[in] phase Phase to smooth pressure
   //! \param[in] pressure_smoothing Enable or disable pressure smoothing
+  //! \param[in] stress_rate Use Cauchy or Jaumann rate of stress
   virtual inline void precompute_stress_strain(unsigned phase,
-                                               bool pressure_smoothing) = 0;
+                                               bool pressure_smoothing,
+                                               mpm::StressRate stress_rate) = 0;
 
   //! Postcompute stress and strain (empty call)
-  //! \param[in] phase Phase to smooth postssure
-  //! \param[in] postssure_smoothing Enable or disable postssure smoothing
-  virtual inline void postcompute_stress_strain(unsigned phase,
-                                                bool pressure_smoothing) = 0;
+  //! \param[in] phase Phase to smooth pressure
+  //! \param[in] pressure_smoothing Enable or disable pressure smoothing
+  //! \param[in] stress_rate Use Cauchy or Jaumann rate of stress
+  virtual inline void postcompute_stress_strain(
+      unsigned phase, bool pressure_smoothing, mpm::StressRate stress_rate) = 0;
 
   //! Pressure smoothing
   //! \param[in] phase Phase to smooth pressure

--- a/include/solvers/mpm_scheme/mpm_scheme.tcc
+++ b/include/solvers/mpm_scheme/mpm_scheme.tcc
@@ -88,7 +88,7 @@ inline void mpm::MPMScheme<Tdim>::compute_stress_strain(
 
   // Iterate over each particle to compute stress
   mesh_->iterate_over_particles(std::bind(
-      &mpm::ParticleBase<Tdim>::compute_stress, std::placeholders::_1));
+      &mpm::ParticleBase<Tdim>::compute_stress, std::placeholders::_1, dt_));
 }
 
 //! Pressure smoothing

--- a/include/solvers/mpm_scheme/mpm_scheme.tcc
+++ b/include/solvers/mpm_scheme/mpm_scheme.tcc
@@ -73,7 +73,7 @@ inline void mpm::MPMScheme<Tdim>::compute_nodal_kinematics(
 //! Compute stress and strain
 template <unsigned Tdim>
 inline void mpm::MPMScheme<Tdim>::compute_stress_strain(
-    unsigned phase, bool pressure_smoothing) {
+    unsigned phase, bool pressure_smoothing, mpm::StressRate stress_rate) {
 
   // Iterate over each particle to calculate strain
   mesh_->iterate_over_particles(std::bind(
@@ -87,8 +87,9 @@ inline void mpm::MPMScheme<Tdim>::compute_stress_strain(
   if (pressure_smoothing) this->pressure_smoothing(phase);
 
   // Iterate over each particle to compute stress
-  mesh_->iterate_over_particles(std::bind(
-      &mpm::ParticleBase<Tdim>::compute_stress, std::placeholders::_1, dt_));
+  mesh_->iterate_over_particles(
+      std::bind(&mpm::ParticleBase<Tdim>::compute_stress, std::placeholders::_1,
+                dt_, stress_rate));
 }
 
 //! Pressure smoothing

--- a/include/solvers/mpm_scheme/mpm_scheme_musl.h
+++ b/include/solvers/mpm_scheme/mpm_scheme_musl.h
@@ -25,15 +25,19 @@ class MPMSchemeMUSL : public MPMScheme<Tdim> {
   MPMSchemeMUSL(const std::shared_ptr<mpm::Mesh<Tdim>>& mesh, double dt);
 
   //! Precompute stress
-  //! \param[in] phase Phase to smooth postssure
-  //! \param[in] pressure_smoothing Enable or disable postssure smoothing
+  //! \param[in] phase Phase to smooth pressure
+  //! \param[in] pressure_smoothing Enable or disable pressure smoothing
+  //! \param[in] stress_rate Use Cauchy or Jaumann rate of stress
   virtual inline void precompute_stress_strain(
-      unsigned phase, bool pressure_smoothing) override;
+      unsigned phase, bool pressure_smoothing,
+      mpm::StressRate stress_rate) override;
   //! Postcompute stress
-  //! \param[in] phase Phase to smooth postssure
-  //! \param[in] pressure_smoothing Enable or disable postssure smoothing
+  //! \param[in] phase Phase to smooth pressure
+  //! \param[in] pressure_smoothing Enable or disable pressure smoothing
+  //! \param[in] stress_rate Use Cauchy or Jaumann rate of stress
   virtual inline void postcompute_stress_strain(
-      unsigned phase, bool pressure_smoothing) override;
+      unsigned phase, bool pressure_smoothing,
+      mpm::StressRate stress_rate) override;
 
   //! Postcompute nodal kinematics - map mass and momentum to nodes
   //! \param[in] velocity_update Method to update nodal velocity

--- a/include/solvers/mpm_scheme/mpm_scheme_musl.tcc
+++ b/include/solvers/mpm_scheme/mpm_scheme_musl.tcc
@@ -7,13 +7,14 @@ mpm::MPMSchemeMUSL<Tdim>::MPMSchemeMUSL(
 //! Precompute stresses and strains
 template <unsigned Tdim>
 inline void mpm::MPMSchemeMUSL<Tdim>::precompute_stress_strain(
-    unsigned phase, bool pressure_smoothing) {}
+    unsigned phase, bool pressure_smoothing, mpm::StressRate stress_rate) {}
 
 //! Postcompute stresses and strains
 template <unsigned Tdim>
 inline void mpm::MPMSchemeMUSL<Tdim>::postcompute_stress_strain(
-    unsigned phase, bool pressure_smoothing) {
-  mpm::MPMScheme<Tdim>::compute_stress_strain(phase, pressure_smoothing);
+    unsigned phase, bool pressure_smoothing, mpm::StressRate stress_rate) {
+  mpm::MPMScheme<Tdim>::compute_stress_strain(phase, pressure_smoothing,
+                                              stress_rate);
 }
 
 //! Postcompute nodal kinematics - map mass and momentum to nodes

--- a/include/solvers/mpm_scheme/mpm_scheme_newmark.h
+++ b/include/solvers/mpm_scheme/mpm_scheme_newmark.h
@@ -30,20 +30,23 @@ class MPMSchemeNewmark : public MPMScheme<Tdim> {
   //! Compute stress and strain
   //! \param[in] phase Phase to smooth pressure
   //! \param[in] pressure_smoothing Enable or disable pressure smoothing
-  inline void compute_stress_strain(unsigned phase,
-                                    bool pressure_smoothing) override;
+  //! \param[in] stress_rate Use Cauchy or Jaumann rate of stress
+  inline void compute_stress_strain(unsigned phase, bool pressure_smoothing,
+                                    mpm::StressRate stress_rate) override;
 
   //! Precompute stress
-  //! \param[in] phase Phase to smooth postssure
-  //! \param[in] postssure_smoothing Enable or disable postssure smoothing
-  inline void precompute_stress_strain(unsigned phase,
-                                       bool pressure_smoothing) override;
+  //! \param[in] phase Phase to smooth pressure
+  //! \param[in] pressure_smoothing Enable or disable pressure smoothing
+  //! \param[in] stress_rate Use Cauchy or Jaumann rate of stress
+  inline void precompute_stress_strain(unsigned phase, bool pressure_smoothing,
+                                       mpm::StressRate stress_rate) override;
 
   //! Postcompute stress
-  //! \param[in] phase Phase to smooth postssure
-  //! \param[in] postssure_smoothing Enable or disable postssure smoothing
-  inline void postcompute_stress_strain(unsigned phase,
-                                        bool pressure_smoothing) override;
+  //! \param[in] phase Phase to smooth pressure
+  //! \param[in] pressure_smoothing Enable or disable pressure smoothing
+  //! \param[in] stress_rate Use Cauchy or Jaumann rate of stress
+  inline void postcompute_stress_strain(unsigned phase, bool pressure_smoothing,
+                                        mpm::StressRate stress_rate) override;
 
   //! Compute acceleration velocity position
   //! \param[in] velocity_update Method to update particle velocity

--- a/include/solvers/mpm_scheme/mpm_scheme_newmark.tcc
+++ b/include/solvers/mpm_scheme/mpm_scheme_newmark.tcc
@@ -86,7 +86,7 @@ inline void mpm::MPMSchemeNewmark<Tdim>::update_nodal_kinematics_newmark(
 //! Compute stress and strain by Newmark scheme
 template <unsigned Tdim>
 inline void mpm::MPMSchemeNewmark<Tdim>::compute_stress_strain(
-    unsigned phase, bool pressure_smoothing) {
+    unsigned phase, bool pressure_smoothing, mpm::StressRate stress_rate) {
 
   // Iterate over each particle to calculate strain and volume using nodal
   // displacement
@@ -105,13 +105,13 @@ inline void mpm::MPMSchemeNewmark<Tdim>::compute_stress_strain(
 //! Precompute stresses and strains
 template <unsigned Tdim>
 inline void mpm::MPMSchemeNewmark<Tdim>::precompute_stress_strain(
-    unsigned phase, bool pressure_smoothing) {}
+    unsigned phase, bool pressure_smoothing, mpm::StressRate stress_rate) {}
 
 //! Postcompute stresses and strains
 template <unsigned Tdim>
 inline void mpm::MPMSchemeNewmark<Tdim>::postcompute_stress_strain(
-    unsigned phase, bool pressure_smoothing) {
-  this->compute_stress_strain(phase, pressure_smoothing);
+    unsigned phase, bool pressure_smoothing, mpm::StressRate stress_rate) {
+  this->compute_stress_strain(phase, pressure_smoothing, stress_rate);
 }
 
 // Compute forces

--- a/include/solvers/mpm_scheme/mpm_scheme_usf.h
+++ b/include/solvers/mpm_scheme/mpm_scheme_usf.h
@@ -19,15 +19,20 @@ class MPMSchemeUSF : public MPMScheme<Tdim> {
   MPMSchemeUSF(const std::shared_ptr<mpm::Mesh<Tdim>>& mesh, double dt);
 
   //! Precompute stress
-  //! \param[in] phase Phase to smooth postssure
-  //! \param[in] postssure_smoothing Enable or disable postssure smoothing
+  //! \param[in] phase Phase to smooth pressure
+  //! \param[in] pressure_smoothing Enable or disable pressure smoothing
+  //! \param[in] stress_rate Use Cauchy or Jaumann rate of stress
   virtual inline void precompute_stress_strain(
-      unsigned phase, bool pressure_smoothing) override;
+      unsigned phase, bool pressure_smoothing,
+      mpm::StressRate stress_rate) override;
+
   //! Postcompute stress
-  //! \param[in] phase Phase to smooth postssure
-  //! \param[in] postssure_smoothing Enable or disable postssure smoothing
+  //! \param[in] phase Phase to smooth pressure
+  //! \param[in] pressure_smoothing Enable or disable pressure smoothing
+  //! \param[in] stress_rate Use Cauchy or Jaumann rate of stress
   virtual inline void postcompute_stress_strain(
-      unsigned phase, bool pressure_smoothing) override;
+      unsigned phase, bool pressure_smoothing,
+      mpm::StressRate stress_rate) override;
 
   //! Postcompute nodal kinematics - map mass and momentum to nodes
   //! \param[in] velocity_update Method to update nodal velocity

--- a/include/solvers/mpm_scheme/mpm_scheme_usf.tcc
+++ b/include/solvers/mpm_scheme/mpm_scheme_usf.tcc
@@ -7,14 +7,14 @@ mpm::MPMSchemeUSF<Tdim>::MPMSchemeUSF(
 //! Precompute stresses and strains
 template <unsigned Tdim>
 inline void mpm::MPMSchemeUSF<Tdim>::precompute_stress_strain(
-    unsigned phase, bool pressure_smoothing) {
-  this->compute_stress_strain(phase, pressure_smoothing);
+    unsigned phase, bool pressure_smoothing, mpm::StressRate stress_rate) {
+  this->compute_stress_strain(phase, pressure_smoothing, stress_rate);
 }
 
 //! Postcompute stresses and strains
 template <unsigned Tdim>
 inline void mpm::MPMSchemeUSF<Tdim>::postcompute_stress_strain(
-    unsigned phase, bool pressure_smoothing) {}
+    unsigned phase, bool pressure_smoothing, mpm::StressRate stress_rate) {}
 
 //! Postcompute nodal kinematics - map mass and momentum to nodes
 template <unsigned Tdim>

--- a/include/solvers/mpm_scheme/mpm_scheme_usl.h
+++ b/include/solvers/mpm_scheme/mpm_scheme_usl.h
@@ -19,15 +19,20 @@ class MPMSchemeUSL : public MPMScheme<Tdim> {
   MPMSchemeUSL(const std::shared_ptr<mpm::Mesh<Tdim>>& mesh, double dt);
 
   //! Precompute stress
-  //! \param[in] phase Phase to smooth postssure
-  //! \param[in] postssure_smoothing Enable or disable postssure smoothing
+  //! \param[in] phase Phase to smooth pressure
+  //! \param[in] pressure_smoothing Enable or disable pressure smoothing
+  //! \param[in] stress_rate Use Cauchy or Jaumann rate of stress
   virtual inline void precompute_stress_strain(
-      unsigned phase, bool pressure_smoothing) override;
+      unsigned phase, bool pressure_smoothing,
+      mpm::StressRate stress_rate) override;
+
   //! Postcompute stress
-  //! \param[in] phase Phase to smooth postssure
-  //! \param[in] postssure_smoothing Enable or disable postssure smoothing
+  //! \param[in] phase Phase to smooth pressure
+  //! \param[in] pressure_smoothing Enable or disable pressure smoothing
+  //! \param[in] stress_rate Use Cauchy or Jaumann rate of stress
   virtual inline void postcompute_stress_strain(
-      unsigned phase, bool pressure_smoothing) override;
+      unsigned phase, bool pressure_smoothing,
+      mpm::StressRate stress_rate) override;
 
   //! Postcompute nodal kinematics - map mass and momentum to nodes
   //! \param[in] velocity_update Method to update nodal velocity

--- a/include/solvers/mpm_scheme/mpm_scheme_usl.tcc
+++ b/include/solvers/mpm_scheme/mpm_scheme_usl.tcc
@@ -7,13 +7,14 @@ mpm::MPMSchemeUSL<Tdim>::MPMSchemeUSL(
 //! Precompute stresses and strains
 template <unsigned Tdim>
 inline void mpm::MPMSchemeUSL<Tdim>::precompute_stress_strain(
-    unsigned phase, bool pressure_smoothing) {}
+    unsigned phase, bool pressure_smoothing, mpm::StressRate stress_rate) {}
 
 //! Postcompute stresses and strains
 template <unsigned Tdim>
 inline void mpm::MPMSchemeUSL<Tdim>::postcompute_stress_strain(
-    unsigned phase, bool pressure_smoothing) {
-  mpm::MPMScheme<Tdim>::compute_stress_strain(phase, pressure_smoothing);
+    unsigned phase, bool pressure_smoothing, mpm::StressRate stress_rate) {
+  mpm::MPMScheme<Tdim>::compute_stress_strain(phase, pressure_smoothing,
+                                              stress_rate);
 }
 
 //! Postcompute nodal kinematics - map mass and momentum to nodes

--- a/include/solvers/mpm_semi_implicit_navierstokes.tcc
+++ b/include/solvers/mpm_semi_implicit_navierstokes.tcc
@@ -200,8 +200,9 @@ bool mpm::MPMSemiImplicitNavierStokes<Tdim>::solve() {
         &mpm::ParticleBase<Tdim>::compute_strain, std::placeholders::_1, dt_));
 
     // Iterate over each particle to compute shear (deviatoric) stress
-    mesh_->iterate_over_particles(std::bind(
-        &mpm::ParticleBase<Tdim>::compute_stress, std::placeholders::_1, dt_));
+    mesh_->iterate_over_particles(
+        std::bind(&mpm::ParticleBase<Tdim>::compute_stress,
+                  std::placeholders::_1, dt_, mpm::StressRate::None));
 
     // Spawn a task for external force
 #pragma omp parallel sections

--- a/include/solvers/mpm_semi_implicit_navierstokes.tcc
+++ b/include/solvers/mpm_semi_implicit_navierstokes.tcc
@@ -201,7 +201,7 @@ bool mpm::MPMSemiImplicitNavierStokes<Tdim>::solve() {
 
     // Iterate over each particle to compute shear (deviatoric) stress
     mesh_->iterate_over_particles(std::bind(
-        &mpm::ParticleBase<Tdim>::compute_stress, std::placeholders::_1));
+        &mpm::ParticleBase<Tdim>::compute_stress, std::placeholders::_1, dt_));
 
     // Spawn a task for external force
 #pragma omp parallel sections

--- a/include/solvers/mpm_semi_implicit_twophase.tcc
+++ b/include/solvers/mpm_semi_implicit_twophase.tcc
@@ -20,8 +20,9 @@ void mpm::MPMSemiImplicitTwoPhase<Tdim>::compute_stress_strain() {
   mesh_->iterate_over_particles(std::bind(
       &mpm::ParticleBase<Tdim>::update_porosity, std::placeholders::_1, dt_));
   // Iterate over each particle to compute stress of soil skeleton
-  mesh_->iterate_over_particles(std::bind(
-      &mpm::ParticleBase<Tdim>::compute_stress, std::placeholders::_1, dt_));
+  mesh_->iterate_over_particles(
+      std::bind(&mpm::ParticleBase<Tdim>::compute_stress, std::placeholders::_1,
+                dt_, mpm::StressRate::None));
   // Pressure smoothing
   if (pressure_smoothing_) this->pressure_smoothing(mpm::ParticlePhase::Solid);
   // Pore pressure smoothing

--- a/include/solvers/mpm_semi_implicit_twophase.tcc
+++ b/include/solvers/mpm_semi_implicit_twophase.tcc
@@ -21,7 +21,7 @@ void mpm::MPMSemiImplicitTwoPhase<Tdim>::compute_stress_strain() {
       &mpm::ParticleBase<Tdim>::update_porosity, std::placeholders::_1, dt_));
   // Iterate over each particle to compute stress of soil skeleton
   mesh_->iterate_over_particles(std::bind(
-      &mpm::ParticleBase<Tdim>::compute_stress, std::placeholders::_1));
+      &mpm::ParticleBase<Tdim>::compute_stress, std::placeholders::_1, dt_));
   // Pressure smoothing
   if (pressure_smoothing_) this->pressure_smoothing(mpm::ParticlePhase::Solid);
   // Pore pressure smoothing

--- a/include/utilities/math_utility.tcc
+++ b/include/utilities/math_utility.tcc
@@ -1,5 +1,14 @@
 //! Convert 2nd-order symmetric tensor from voigt notation to full matrix form
 template <>
+inline const Eigen::Matrix<double, 1, 1> mpm::math::matrix_form<1>(
+    const Eigen::Matrix<double, 6, 1>& voigt_tensor) {
+  Eigen::Matrix<double, 1, 1> matrix_tensor;
+  matrix_tensor(0, 0) = voigt_tensor(0);
+  return matrix_tensor;
+}
+
+//! Convert 2nd-order symmetric tensor from voigt notation to full matrix form
+template <>
 inline const Eigen::Matrix<double, 2, 2> mpm::math::matrix_form<2>(
     const Eigen::Matrix<double, 6, 1>& voigt_tensor) {
   Eigen::Matrix<double, 2, 2> matrix_tensor;

--- a/include/utilities/math_utility.tcc
+++ b/include/utilities/math_utility.tcc
@@ -45,6 +45,16 @@ inline const Eigen::Matrix<double, 3, 3> mpm::math::matrix_form(
 
 //! Convert 2nd-order symmetric tensor from full matrix form to voigt notation
 template <>
+inline const Eigen::Matrix<double, 6, 1> mpm::math::voigt_form<1>(
+    const Eigen::Matrix<double, 1, 1>& matrix_tensor) {
+  Eigen::Matrix<double, 6, 1> voigt_tensor =
+      Eigen::Matrix<double, 6, 1>::Zero();
+  voigt_tensor(0) = matrix_tensor(0, 0);
+  return voigt_tensor;
+}
+
+//! Convert 2nd-order symmetric tensor from full matrix form to voigt notation
+template <>
 inline const Eigen::Matrix<double, 6, 1> mpm::math::voigt_form<2>(
     const Eigen::Matrix<double, 2, 2>& matrix_tensor) {
   Eigen::Matrix<double, 6, 1> voigt_tensor =

--- a/tests/functions/math_utility_test.cc
+++ b/tests/functions/math_utility_test.cc
@@ -19,6 +19,13 @@ TEST_CASE("math utility is checked", "[math]") {
     stress.setZero();
 
     // Vector to matrix conversion
+    auto stress_1d = mpm::math::matrix_form<1>(stress);
+    REQUIRE(stress_1d.cols() == 1);
+    REQUIRE(stress_1d.rows() == 1);
+    for (unsigned i = 0; i < 1; i++)
+      for (unsigned j = 0; j < 1; j++)
+        REQUIRE(stress_1d(i, j) == Approx(0.).epsilon(Tolerance));
+
     auto stress_2d = mpm::math::matrix_form<2>(stress);
     REQUIRE(stress_2d.cols() == 2);
     REQUIRE(stress_2d.rows() == 2);
@@ -39,6 +46,10 @@ TEST_CASE("math utility is checked", "[math]") {
     for (unsigned i = 0; i < 3; i++)
       for (unsigned j = 0; j < 3; j++)
         REQUIRE(stress_3d(i, j) == Approx(0.).epsilon(Tolerance));
+
+    auto voigt_stress_1d = mpm::math::voigt_form<1>(stress_1d);
+    for (unsigned i = 0; i < 6; i++)
+      REQUIRE(voigt_stress_1d(i) == Approx(stress(i)).epsilon(Tolerance));
 
     auto voigt_stress_2d = mpm::math::voigt_form<2>(stress_2d);
     for (unsigned i = 0; i < 6; i++)
@@ -106,6 +117,14 @@ TEST_CASE("math utility is checked", "[math]") {
     stress(4) = -14.5;
     stress(5) = -33.;
 
+    Eigen::Matrix<double, 6, 1> stress_1dim;
+    stress_1dim(0) = -200.;
+    stress_1dim(1) = 0.0;
+    stress_1dim(2) = 0.0;
+    stress_1dim(3) = 0.0;
+    stress_1dim(4) = 0.0;
+    stress_1dim(5) = 0.0;
+
     Eigen::Matrix<double, 6, 1> stress_2dim;
     stress_2dim(0) = -200.;
     stress_2dim(1) = -150.2;
@@ -126,6 +145,14 @@ TEST_CASE("math utility is checked", "[math]") {
     stress_matrix(2, 0) = -33.;
 
     // Vector to matrix conversion
+    auto stress_1d = mpm::math::matrix_form<1>(stress);
+    REQUIRE(stress_1d.cols() == 1);
+    REQUIRE(stress_1d.rows() == 1);
+    for (unsigned i = 0; i < 1; i++)
+      for (unsigned j = 0; j < 1; j++)
+        REQUIRE(stress_1d(i, j) ==
+                Approx(stress_matrix(i, j)).epsilon(Tolerance));
+
     auto stress_2d = mpm::math::matrix_form<2>(stress);
     REQUIRE(stress_2d.cols() == 2);
     REQUIRE(stress_2d.rows() == 2);
@@ -149,6 +176,10 @@ TEST_CASE("math utility is checked", "[math]") {
       for (unsigned j = 0; j < 3; j++)
         REQUIRE(stress_3d(i, j) ==
                 Approx(stress_matrix(i, j)).epsilon(Tolerance));
+
+    auto voigt_stress_1d = mpm::math::voigt_form<1>(stress_1d);
+    for (unsigned i = 0; i < 6; i++)
+      REQUIRE(voigt_stress_1d(i) == Approx(stress_1dim(i)).epsilon(Tolerance));
 
     auto voigt_stress_2d = mpm::math::voigt_form<2>(stress_2d);
     for (unsigned i = 0; i < 6; i++)

--- a/tests/io/write_mesh_particles_unitcell.cc
+++ b/tests/io/write_mesh_particles_unitcell.cc
@@ -13,6 +13,7 @@ bool write_json_unitcell(unsigned dim, const std::string& analysis,
   auto node_type = "N2D";
   auto cell_type = "ED2Q4";
   auto io_type = "Ascii2D";
+  auto stress_rate = "jaumann";
   std::string material = "LinearElastic2D";
   std::vector<unsigned> material_id{{1}};
   std::vector<double> gravity{{0., -9.81}};
@@ -26,6 +27,7 @@ bool write_json_unitcell(unsigned dim, const std::string& analysis,
     node_type = "N3D";
     cell_type = "ED3H8";
     io_type = "Ascii3D";
+    stress_rate = "error";
     material = "LinearElastic3D";
     gravity.clear();
     gravity = {0., 0., -9.81};
@@ -87,6 +89,7 @@ bool write_json_unitcell(unsigned dim, const std::string& analysis,
       {"analysis",
        {{"type", analysis},
         {"mpm_scheme", mpm_scheme},
+        {"stress_rate", stress_rate},
         {"velocity_update", "flip"},
         {"locate_particles", true},
         {"dt", 0.001},

--- a/tests/particles/particle_bbar_test.cc
+++ b/tests/particles/particle_bbar_test.cc
@@ -274,7 +274,7 @@ TEST_CASE("ParticleBbar is checked for 2D case", "[particle][2D][Bbar]") {
     REQUIRE(particle->volume() == Approx(1.2).epsilon(Tolerance));
 
     // Compute stress
-    REQUIRE_NOTHROW(particle->compute_stress());
+    REQUIRE_NOTHROW(particle->compute_stress(dt));
 
     Eigen::Matrix<double, 6, 1> stress;
     // clang-format off
@@ -621,7 +621,7 @@ TEST_CASE("ParticleBbar is checked for 3D case", "[particle][3D][Bbar]") {
     REQUIRE(particle->volume() == Approx(12.0).epsilon(Tolerance));
 
     // Compute stress
-    REQUIRE_NOTHROW(particle->compute_stress());
+    REQUIRE_NOTHROW(particle->compute_stress(dt));
     Eigen::Matrix<double, 6, 1> stress;
     // clang-format off
     stress << 2948717.9487179490,

--- a/tests/particles/particle_finite_strain_test.cc
+++ b/tests/particles/particle_finite_strain_test.cc
@@ -282,7 +282,7 @@ TEST_CASE("ParticleFiniteStrain is checked for 2D case",
     REQUIRE(particle->volume() == Approx(1.25).epsilon(Tolerance));
 
     // Compute stress
-    REQUIRE_NOTHROW(particle->compute_stress());
+    REQUIRE_NOTHROW(particle->compute_stress(dt));
 
     Eigen::Matrix<double, 6, 1> stress;
     // clang-format off
@@ -633,7 +633,7 @@ TEST_CASE("ParticleFiniteStrain is checked for 3D case",
     REQUIRE(particle->volume() == Approx(11.8).epsilon(Tolerance));
 
     // Compute stress
-    REQUIRE_NOTHROW(particle->compute_stress());
+    REQUIRE_NOTHROW(particle->compute_stress(dt));
     Eigen::Matrix<double, 6, 1> stress;
     // clang-format off
     stress << 1517827.6913974094,

--- a/tests/particles/particle_test.cc
+++ b/tests/particles/particle_test.cc
@@ -1137,6 +1137,26 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
     for (unsigned i = 0; i < stress.rows(); ++i)
       REQUIRE(particle->stress()(i) == Approx(stress(i)).epsilon(Tolerance));
 
+    // Compute stress (Jaumann)
+    REQUIRE_NOTHROW(particle->compute_stress(dt, mpm::StressRate::Jaumann));
+
+    Eigen::Matrix<double, 6, 1> stress_Jaumann;
+    // clang-format off
+    stress_Jaumann << 2875000.00000000,
+                      6740384.61538462,
+                      2884615.38461538,
+                      336538.461538460,
+                      0.,
+                      0.;
+    // clang-format on
+    // Check stress
+    for (unsigned i = 0; i < stress_Jaumann.rows(); ++i)
+      REQUIRE(particle->stress()(i) ==
+              Approx(stress_Jaumann(i)).epsilon(Tolerance));
+
+    // Put stress back to values from Lines 1129-1134
+    particle->initial_stress(stress);
+
     // Check body force
     Eigen::Matrix<double, 2, 1> gravity;
     gravity << 0., -9.81;
@@ -2638,6 +2658,26 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     // Check stress
     for (unsigned i = 0; i < stress.rows(); ++i)
       REQUIRE(particle->stress()(i) == Approx(stress(i)).epsilon(Tolerance));
+
+    // Compute stress (Jaumann)
+    REQUIRE_NOTHROW(particle->compute_stress(dt, mpm::StressRate::Jaumann));
+
+    Eigen::Matrix<double, 6, 1> stress_Jaumann;
+    // clang-format off
+    stress_Jaumann << 5468750.00000000,
+                      6704326.92307692,
+                     11576923.07692308,
+                      -156250.00000000,
+                      2759615.38461539,
+                      -288461.53846154;
+    // clang-format on
+    // Check stress
+    for (unsigned i = 0; i < stress_Jaumann.rows(); ++i)
+      REQUIRE(particle->stress()(i) ==
+              Approx(stress_Jaumann(i)).epsilon(Tolerance));
+
+    // Put stress back to values from Lines 2651-2656
+    particle->initial_stress(stress);
 
     // Check body force
     Eigen::Matrix<double, 3, 1> gravity;

--- a/tests/particles/particle_test.cc
+++ b/tests/particles/particle_test.cc
@@ -1121,7 +1121,7 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
     REQUIRE(particle->volume() == Approx(1.2).epsilon(Tolerance));
 
     // Compute stress
-    REQUIRE_NOTHROW(particle->compute_stress());
+    REQUIRE_NOTHROW(particle->compute_stress(dt));
 
     Eigen::Matrix<double, 6, 1> stress;
     // clang-format off
@@ -1351,7 +1351,7 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
               Approx(volumetric_strain).epsilon(Tolerance));
 
       // Compute stress
-      REQUIRE_NOTHROW(particle->compute_stress());
+      REQUIRE_NOTHROW(particle->compute_stress(dt));
 
       REQUIRE(
           particle->pressure() ==
@@ -2623,7 +2623,7 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
     REQUIRE(particle->volume() == Approx(12.0).epsilon(Tolerance));
 
     // Compute stress
-    REQUIRE_NOTHROW(particle->compute_stress());
+    REQUIRE_NOTHROW(particle->compute_stress(dt));
 
     Eigen::Matrix<double, 6, 1> stress;
     // clang-format off
@@ -2829,7 +2829,7 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
               Approx(volumetric_strain).epsilon(Tolerance));
 
       // Compute stress
-      REQUIRE_NOTHROW(particle->compute_stress());
+      REQUIRE_NOTHROW(particle->compute_stress(dt));
 
       REQUIRE(
           particle->pressure() ==

--- a/tests/particles/particle_test.cc
+++ b/tests/particles/particle_test.cc
@@ -8,6 +8,7 @@
 #include "hexahedron_element.h"
 #include "linear_function.h"
 #include "material.h"
+#include "math_utility.h"
 #include "node.h"
 #include "particle.h"
 #include "pod_particle.h"

--- a/tests/particles/particle_twophase_test.cc
+++ b/tests/particles/particle_twophase_test.cc
@@ -1095,7 +1095,7 @@ TEST_CASE("TwoPhase Particle is checked for 2D case",
     REQUIRE(particle->volume() == Approx(1.2).epsilon(Tolerance));
 
     // Compute stress
-    REQUIRE_NOTHROW(particle->compute_stress());
+    REQUIRE_NOTHROW(particle->compute_stress(dt));
 
     Eigen::Matrix<double, 6, 1> stress;
     // clang-format off
@@ -2615,7 +2615,7 @@ TEST_CASE("TwoPhase Particle is checked for 3D case",
     REQUIRE(particle->volume() == Approx(12.0).epsilon(Tolerance));
 
     // Compute stress
-    REQUIRE_NOTHROW(particle->compute_stress());
+    REQUIRE_NOTHROW(particle->compute_stress(dt));
 
     Eigen::Matrix<double, 6, 1> stress;
     // clang-format off
@@ -2832,7 +2832,7 @@ TEST_CASE("TwoPhase Particle is checked for 3D case",
               Approx(volumetric_strain).epsilon(Tolerance));
 
       // Compute stress
-      REQUIRE_NOTHROW(particle->compute_stress());
+      REQUIRE_NOTHROW(particle->compute_stress(dt));
 
       REQUIRE(
           particle->pressure() ==

--- a/tests/solvers/mpm_scheme_test.cc
+++ b/tests/solvers/mpm_scheme_test.cc
@@ -187,8 +187,10 @@ TEST_CASE("Stress update is checked for USF, USL and MUSL",
         mpm_scheme->compute_nodal_kinematics(mpm::VelocityUpdate::FLIP, phase));
 
     // Update stress first
-    REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(phase, false));
-    REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(phase, true));
+    REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(
+        phase, false, mpm::StressRate::None));
+    REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(
+        phase, true, mpm::StressRate::None));
 
     // Compute forces
     REQUIRE_NOTHROW(mpm_scheme->compute_forces(gravity, phase, step, false));
@@ -205,8 +207,10 @@ TEST_CASE("Stress update is checked for USF, USL and MUSL",
         mpm::VelocityUpdate::FLIP, 1.0, phase, "None", 0.02, step, false));
 
     // Update Stress Last
-    REQUIRE_NOTHROW(mpm_scheme->postcompute_stress_strain(phase, true));
-    REQUIRE_NOTHROW(mpm_scheme->postcompute_stress_strain(phase, false));
+    REQUIRE_NOTHROW(mpm_scheme->postcompute_stress_strain(
+        phase, true, mpm::StressRate::None));
+    REQUIRE_NOTHROW(mpm_scheme->postcompute_stress_strain(
+        phase, false, mpm::StressRate::None));
 
     // Locate particles
     REQUIRE_NOTHROW(mpm_scheme->locate_particles(true));
@@ -229,8 +233,10 @@ TEST_CASE("Stress update is checked for USF, USL and MUSL",
         mpm_scheme->compute_nodal_kinematics(mpm::VelocityUpdate::FLIP, phase));
 
     // Update stress first
-    REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(phase, false));
-    REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(phase, true));
+    REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(
+        phase, false, mpm::StressRate::None));
+    REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(
+        phase, true, mpm::StressRate::None));
 
     // Compute forces
     REQUIRE_NOTHROW(mpm_scheme->compute_forces(gravity, phase, step, false));
@@ -247,8 +253,10 @@ TEST_CASE("Stress update is checked for USF, USL and MUSL",
         mpm::VelocityUpdate::FLIP, 1.0, phase, "None", 0.02, step, true));
 
     // Update Stress Last
-    REQUIRE_NOTHROW(mpm_scheme->postcompute_stress_strain(phase, true));
-    REQUIRE_NOTHROW(mpm_scheme->postcompute_stress_strain(phase, false));
+    REQUIRE_NOTHROW(mpm_scheme->postcompute_stress_strain(
+        phase, true, mpm::StressRate::None));
+    REQUIRE_NOTHROW(mpm_scheme->postcompute_stress_strain(
+        phase, false, mpm::StressRate::None));
 
     // Locate particles
     REQUIRE_NOTHROW(mpm_scheme->locate_particles(true));
@@ -271,8 +279,10 @@ TEST_CASE("Stress update is checked for USF, USL and MUSL",
         mpm_scheme->compute_nodal_kinematics(mpm::VelocityUpdate::FLIP, phase));
 
     // Update stress first
-    REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(phase, false));
-    REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(phase, true));
+    REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(
+        phase, false, mpm::StressRate::None));
+    REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(
+        phase, true, mpm::StressRate::None));
 
     // Compute forces
     REQUIRE_NOTHROW(mpm_scheme->compute_forces(gravity, phase, step, false));
@@ -289,8 +299,10 @@ TEST_CASE("Stress update is checked for USF, USL and MUSL",
         mpm::VelocityUpdate::FLIP, 1.0, phase, "None", 0.02, step, true));
 
     // Update Stress Last
-    REQUIRE_NOTHROW(mpm_scheme->postcompute_stress_strain(phase, true));
-    REQUIRE_NOTHROW(mpm_scheme->postcompute_stress_strain(phase, false));
+    REQUIRE_NOTHROW(mpm_scheme->postcompute_stress_strain(
+        phase, true, mpm::StressRate::None));
+    REQUIRE_NOTHROW(mpm_scheme->postcompute_stress_strain(
+        phase, false, mpm::StressRate::None));
 
     // Locate particles
     REQUIRE_NOTHROW(mpm_scheme->locate_particles(true));
@@ -317,8 +329,10 @@ TEST_CASE("Stress update is checked for USF, USL and MUSL",
         mpm_scheme->compute_nodal_kinematics(mpm::VelocityUpdate::FLIP, phase));
 
     // Update stress first
-    REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(phase, false));
-    REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(phase, true));
+    REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(
+        phase, false, mpm::StressRate::None));
+    REQUIRE_NOTHROW(mpm_scheme->precompute_stress_strain(
+        phase, true, mpm::StressRate::None));
 
     // Compute forces
     REQUIRE_NOTHROW(
@@ -333,8 +347,10 @@ TEST_CASE("Stress update is checked for USF, USL and MUSL",
         mpm::VelocityUpdate::PIC, 0.0, phase, "None", 0.02, step, false));
 
     // Update Stress Last
-    REQUIRE_NOTHROW(mpm_scheme->postcompute_stress_strain(phase, true));
-    REQUIRE_NOTHROW(mpm_scheme->postcompute_stress_strain(phase, false));
+    REQUIRE_NOTHROW(mpm_scheme->postcompute_stress_strain(
+        phase, true, mpm::StressRate::None));
+    REQUIRE_NOTHROW(mpm_scheme->postcompute_stress_strain(
+        phase, false, mpm::StressRate::None));
 
     // Locate particles
     REQUIRE_NOTHROW(mpm_scheme->locate_particles(true));


### PR DESCRIPTION
## Describe the PR
Add *incremental form* of Jaumann rate of Cauchy stress tensor to `compute_stress()`.

### New Variables in `compute_stress()`
`dt` is a double with  simutlation time step.
`stress_rate` is a new type of variable called `mpm::StressRate`.

## Testing
PR includes some minor updates to existing testing so that `./mpmtest_small` and `./mpmtest_unit` continue to pass. 

### "Small" Test Passing
![image](https://github.com/geomechanics/mpm/assets/62029065/6ecdc838-ffff-4625-888b-d76e4ff21daf)

### "Unit" Test Passing
![image](https://github.com/geomechanics/mpm/assets/62029065/4ccb6e2c-eb4f-4558-b83b-3d5fa1f6d239)

### Additional Coverage
Additional testing coverage will be added once the current implementation is approved.