### PR TITLE
BC nomenclature cohesion to adhesion :truck:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,7 +289,7 @@ if(MPM_BUILD_TESTING)
     ${mpm_SOURCE_DIR}/tests/solvers/mpm_explicit_constraint_absorbing_test.cc
     ${mpm_SOURCE_DIR}/tests/solvers/mpm_explicit_constraint_acceleration_test.cc
     ${mpm_SOURCE_DIR}/tests/solvers/mpm_explicit_constraint_friction_test.cc
-    ${mpm_SOURCE_DIR}/tests/solvers/mpm_explicit_constraint_cohesion_test.cc
+    ${mpm_SOURCE_DIR}/tests/solvers/mpm_explicit_constraint_adhesion_test.cc
     ${mpm_SOURCE_DIR}/tests/solvers/mpm_explicit_constraint_velocity_test.cc
     ${mpm_SOURCE_DIR}/tests/solvers/mpm_explicit_finite_strain_test.cc
     ${mpm_SOURCE_DIR}/tests/solvers/mpm_explicit_finite_strain_unitcell_test.cc

--- a/include/io/io_mesh.h
+++ b/include/io/io_mesh.h
@@ -116,12 +116,12 @@ class IOMesh {
       read_friction_constraints(
           const std::string& friction_constraints_file) = 0;
 
-  //! Read cohesion constraints file
-  //! \param[in] cohesion_constraints_file file name with cohesion values
+  //! Read adhesion constraints file
+  //! \param[in] adhesion_constraints_file file name with adhesion values
   virtual std::vector<
       std::tuple<mpm::Index, unsigned, int, double, double, int>>
-      read_cohesion_constraints(
-          const std::string& cohesion_constraints_file) = 0;
+      read_adhesion_constraints(
+          const std::string& adhesion_constraints_file) = 0;
 
   //! Read forces file
   //! \param[in] forces_file file name with nodal concentrated force

--- a/include/io/io_mesh_ascii.h
+++ b/include/io/io_mesh_ascii.h
@@ -104,11 +104,11 @@ class IOMeshAscii : public IOMesh<Tdim> {
       read_friction_constraints(
           const std::string& friction_constraints_file) override;
 
-  //! Read cohesion constraints file
-  //! \param[in] cohesion_constraints_file file name with cohesion values
+  //! Read adhesion constraints file
+  //! \param[in] adhesion_constraints_file file name with adhesion values
   std::vector<std::tuple<mpm::Index, unsigned, int, double, double, int>>
-      read_cohesion_constraints(
-          const std::string& cohesion_constraints_file) override;
+      read_adhesion_constraints(
+          const std::string& adhesion_constraints_file) override;
 
   //! Read traction file
   //! \param[in] forces_file file name with nodal concentrated force

--- a/include/io/io_mesh_ascii.tcc
+++ b/include/io/io_mesh_ascii.tcc
@@ -692,20 +692,20 @@ std::vector<std::tuple<mpm::Index, unsigned, int, double>>
   return constraints;
 }
 
-//! Return cohesion constraints of particles
+//! Return adhesion constraints of particles
 template <unsigned Tdim>
 std::vector<std::tuple<mpm::Index, unsigned, int, double, double, int>>
-    mpm::IOMeshAscii<Tdim>::read_cohesion_constraints(
-        const std::string& cohesion_constraints_file) {
+    mpm::IOMeshAscii<Tdim>::read_adhesion_constraints(
+        const std::string& adhesion_constraints_file) {
 
-  // Nodal cohesion constraints
+  // Nodal adhesion constraints
   std::vector<std::tuple<mpm::Index, unsigned, int, double, double, int>>
       constraints;
   constraints.clear();
 
   // input file stream
   std::fstream file;
-  file.open(cohesion_constraints_file.c_str(), std::ios::in);
+  file.open(adhesion_constraints_file.c_str(), std::ios::in);
 
   try {
     if (file.is_open() && file.good()) {
@@ -723,17 +723,17 @@ std::vector<std::tuple<mpm::Index, unsigned, int, double, double, int>>
           unsigned dir;
           // Sign of normal direction
           int sign_n;
-          // Cohesion
-          double cohesion;
+          // Adhesion
+          double adhesion;
           // Cell height
           double h_min;
           // Node nposition
           int nposition = 0;
           while (istream.good()) {
             // Read stream
-            istream >> id >> dir >> sign_n >> cohesion >> h_min >> nposition;
+            istream >> id >> dir >> sign_n >> adhesion >> h_min >> nposition;
             constraints.emplace_back(
-                std::make_tuple(id, dir, sign_n, cohesion, h_min, nposition));
+                std::make_tuple(id, dir, sign_n, adhesion, h_min, nposition));
           }
         }
       }
@@ -742,7 +742,7 @@ std::vector<std::tuple<mpm::Index, unsigned, int, double, double, int>>
     }
     file.close();
   } catch (std::exception& exception) {
-    console_->error("Read cohesion constraints: {}", exception.what());
+    console_->error("Read adhesion constraints: {}", exception.what());
     file.close();
   }
   return constraints;

--- a/include/loads_bcs/adhesion_constraint.h
+++ b/include/loads_bcs/adhesion_constraint.h
@@ -1,28 +1,28 @@
-#ifndef MPM_COHESION_CONSTRAINT_H_
-#define MPM_COHESION_CONSTRAINT_H_
+#ifndef MPM_ADHESION_CONSTRAINT_H_
+#define MPM_ADHESION_CONSTRAINT_H_
 
 #include "data_types.h"
 
 namespace mpm {
 
-//! CohesionConstraint class to store cohesion constraint on a set
-//! \brief CohesionConstraint class to store a constraint on a set
-//! \details CohesionConstraint stores the constraint as a static value
-class CohesionConstraint {
+//! AdhesionConstraint class to store adhesion constraint on a set
+//! \brief AdhesionConstraint class to store a constraint on a set
+//! \details AdhesionConstraint stores the constraint as a static value
+class AdhesionConstraint {
  public:
   // Constructor
   //! \param[in] setid  set id
   //! \param[in] dir Direction of constraint load (normal)
   //! \param[in] sign_n Sign of normal vector
-  //! \param[in] cohesion Constraint cohesion
+  //! \param[in] adhesion Constraint adhesion
   //! \param[in] h_min Characteristic length (cell height)
   //! \param[in] nposition Nodal location, nposition, along boundary
-  CohesionConstraint(int setid, unsigned dir, int sign_n, double cohesion,
+  AdhesionConstraint(int setid, unsigned dir, int sign_n, double adhesion,
                      double h_min, int nposition = 0)
       : setid_{setid},
         dir_{dir},
         sign_n_{sign_n},
-        cohesion_{cohesion},
+        adhesion_{adhesion},
         h_min_{h_min},
         nposition_{nposition} {};
 
@@ -35,8 +35,8 @@ class CohesionConstraint {
   // Sign of normal direction
   int sign_n() const { return sign_n_; }
 
-  // Return cohesion
-  double cohesion() const { return cohesion_; }
+  // Return adhesion
+  double adhesion() const { return adhesion_; }
 
   // Cell height
   double h_min() const { return h_min_; }
@@ -55,12 +55,12 @@ class CohesionConstraint {
   unsigned dir_;
   // Sign of normal direction
   int sign_n_;
-  // Cohesion
-  double cohesion_;
+  // Adhesion
+  double adhesion_;
   // Cell height
   double h_min_;
   // Node nposition
   int nposition_;
 };
 }  // namespace mpm
-#endif  // MPM_COHESION_CONSTRAINT_H_
+#endif  // MPM_ADHESION_CONSTRAINT_H_

--- a/include/loads_bcs/constraints.h
+++ b/include/loads_bcs/constraints.h
@@ -5,7 +5,7 @@
 
 #include "absorbing_constraint.h"
 #include "acceleration_constraint.h"
-#include "cohesion_constraint.h"
+#include "adhesion_constraint.h"
 #include "displacement_constraint.h"
 #include "friction_constraint.h"
 #include "logger.h"
@@ -67,20 +67,20 @@ class Constraints {
       const std::vector<std::tuple<mpm::Index, unsigned, int, double>>&
           friction_constraints);
 
-  //! Assign nodal cohesional constraints
+  //! Assign nodal adhesional constraints
   //! \param[in] setid Node set id
-  //! \param[in] cohesion_constraints Constraint at node, dir, sign_n, cohesion,
+  //! \param[in] adhesion_constraints Constraint at node, dir, sign_n, adhesion,
   //! h_min, nposition
-  bool assign_nodal_cohesional_constraint(
+  bool assign_nodal_adhesional_constraint(
       int nset_id,
-      const std::shared_ptr<mpm::CohesionConstraint>& cconstraints);
+      const std::shared_ptr<mpm::AdhesionConstraint>& aconstraints);
 
-  //! Assign cohesion constraints to nodes
-  //! \param[in] cohesion_constraints Constraint at node, dir, sign_n, cohesion,
+  //! Assign adhesion constraints to nodes
+  //! \param[in] adhesion_constraints Constraint at node, dir, sign_n, adhesion,
   //! h_min, nposition
-  bool assign_nodal_cohesion_constraints(
+  bool assign_nodal_adhesion_constraints(
       const std::vector<std::tuple<mpm::Index, unsigned, int, double, double,
-                                   int>>& cohesion_constraints);
+                                   int>>& adhesion_constraints);
 
   //! Assign nodal pressure constraints
   //! \param[in] mfunction Math function if defined

--- a/include/loads_bcs/constraints.tcc
+++ b/include/loads_bcs/constraints.tcc
@@ -216,27 +216,27 @@ bool mpm::Constraints<Tdim>::assign_nodal_friction_constraints(
   return status;
 }
 
-//! Assign cohesion constraints to nodes
+//! Assign adhesion constraints to nodes
 template <unsigned Tdim>
-bool mpm::Constraints<Tdim>::assign_nodal_cohesional_constraint(
-    int nset_id, const std::shared_ptr<mpm::CohesionConstraint>& cconstraint) {
+bool mpm::Constraints<Tdim>::assign_nodal_adhesional_constraint(
+    int nset_id, const std::shared_ptr<mpm::AdhesionConstraint>& aconstraint) {
   bool status = true;
   try {
-    int set_id = cconstraint->setid();
+    int set_id = aconstraint->setid();
     auto nset = mesh_->nodes(set_id);
     if (nset.size() == 0)
       throw std::runtime_error(
-          "Node set is empty for assignment of cohesion constraints");
-    unsigned dir = cconstraint->dir();
-    int sign_n = cconstraint->sign_n();
-    double cohesion = cconstraint->cohesion();
-    double h_min = cconstraint->h_min();
-    int nposition = cconstraint->nposition();
+          "Node set is empty for assignment of adhesion constraints");
+    unsigned dir = aconstraint->dir();
+    int sign_n = aconstraint->sign_n();
+    double adhesion = aconstraint->adhesion();
+    double h_min = aconstraint->h_min();
+    int nposition = aconstraint->nposition();
     for (auto nitr = nset.cbegin(); nitr != nset.cend(); ++nitr) {
-      if (!(*nitr)->assign_cohesion_constraint(dir, sign_n, cohesion, h_min,
+      if (!(*nitr)->assign_adhesion_constraint(dir, sign_n, adhesion, h_min,
                                                nposition))
         throw std::runtime_error(
-            "Failed to initialise cohesion constraint at node");
+            "Failed to initialise adhesion constraint at node");
     }
   } catch (std::exception& exception) {
     console_->error("{} #{}: {}\n", __FILE__, __LINE__, exception.what());
@@ -245,32 +245,32 @@ bool mpm::Constraints<Tdim>::assign_nodal_cohesional_constraint(
   return status;
 }
 
-//! Assign cohesion constraints to nodes
+//! Assign adhesion constraints to nodes
 template <unsigned Tdim>
-bool mpm::Constraints<Tdim>::assign_nodal_cohesion_constraints(
+bool mpm::Constraints<Tdim>::assign_nodal_adhesion_constraints(
     const std::vector<std::tuple<mpm::Index, unsigned, int, double, double,
-                                 int>>& cohesion_constraints) {
+                                 int>>& adhesion_constraints) {
   bool status = true;
   try {
-    for (const auto& cohesion_constraint : cohesion_constraints) {
+    for (const auto& adhesion_constraint : adhesion_constraints) {
       // Node id
-      mpm::Index nid = std::get<0>(cohesion_constraint);
+      mpm::Index nid = std::get<0>(adhesion_constraint);
       // Direction (normal)
-      unsigned dir = std::get<1>(cohesion_constraint);
+      unsigned dir = std::get<1>(adhesion_constraint);
       // Sign of normal direction
-      int sign_n = std::get<2>(cohesion_constraint);
-      // Cohesion
-      double cohesion = std::get<3>(cohesion_constraint);
+      int sign_n = std::get<2>(adhesion_constraint);
+      // Adhesion
+      double adhesion = std::get<3>(adhesion_constraint);
       // Cell height for area computation
-      double h_min = std::get<4>(cohesion_constraint);
+      double h_min = std::get<4>(adhesion_constraint);
       // Location of node for area computation
-      int nposition = std::get<5>(cohesion_constraint);
+      int nposition = std::get<5>(adhesion_constraint);
 
       // Apply constraint
-      if (!mesh_->node(nid)->assign_cohesion_constraint(dir, sign_n, cohesion,
+      if (!mesh_->node(nid)->assign_adhesion_constraint(dir, sign_n, adhesion,
                                                         h_min, nposition))
         throw std::runtime_error(
-            "Nodal cohesion constraints assignment failed");
+            "Nodal adhesion constraints assignment failed");
     }
   } catch (std::exception& exception) {
     console_->error("{} #{}: {}\n", __FILE__, __LINE__, exception.what());

--- a/include/nodes/node.h
+++ b/include/nodes/node.h
@@ -251,19 +251,19 @@ class Node : public NodeBase<Tdim> {
   //! \param[in] dt Time-step
   void apply_friction_constraints(double dt) override;
 
-  //! Assign cohesion constraint
+  //! Assign adhesion constraint
   //! Directions can take values between 0 and Dim * Nphases
-  //! \param[in] dir Direction of cohesion constraint (normal)
-  //! \param[in] sign_n Sign of normal wrt coordinate system for cohesion
-  //! \param[in] cohesion Applied cohesion constraint
+  //! \param[in] dir Direction of adhesion constraint (normal)
+  //! \param[in] sign_n Sign of normal wrt coordinate system for adhesion
+  //! \param[in] adhesion Applied adhesion constraint
   //! \param[in] h_min Characteristic length (cell height)
   //! \param[in] nposition Nodal location, nposition, along boundary
-  bool assign_cohesion_constraint(unsigned dir, int sign_n, double cohesion,
+  bool assign_adhesion_constraint(unsigned dir, int sign_n, double adhesion,
                                   double h_min, int nposition) override;
 
-  //! Apply cohesion constraints
+  //! Apply adhesion constraints
   //! \param[in] dt Time-step
-  void apply_cohesion_constraints(double dt) override;
+  void apply_adhesion_constraints(double dt) override;
 
   //! Apply absorbing constraint
   //! \param[in] dir Direction of p-wave propagation in model
@@ -647,9 +647,9 @@ class Node : public NodeBase<Tdim> {
   //! Frictional constraints
   bool friction_{false};
   std::tuple<unsigned, int, double> friction_constraint_;
-  //! Cohesion constraints
-  bool cohesion_{false};
-  std::tuple<unsigned, int, double, double> cohesion_constraint_;
+  //! Adhesion constraints
+  bool adhesion_{false};
+  std::tuple<unsigned, int, double, double> adhesion_constraint_;
   //! Mathematical function for pressure
   std::map<unsigned, std::shared_ptr<FunctionBase>> pressure_function_;
   //! Concentrated force

--- a/include/nodes/node_base.h
+++ b/include/nodes/node_base.h
@@ -252,20 +252,20 @@ class NodeBase {
   //! \param[in] dt Time-step
   virtual void apply_friction_constraints(double dt) = 0;
 
-  //! Assign cohesion constraint
+  //! Assign adhesion constraint
   //! Directions can take values between 0 and Dim * Nphases
-  //! \param[in] dir Direction of cohesion constraint (normal)
-  //! \param[in] sign_n Sign of normal wrt coordinate system for cohesion
-  //! \param[in] cohesion Applied cohesion constraint
+  //! \param[in] dir Direction of adhesion constraint (normal)
+  //! \param[in] sign_n Sign of normal wrt coordinate system for adhesion
+  //! \param[in] adhesion Applied adhesion constraint
   //! \param[in] h_min Characteristic length (cell height)
   //! \param[in] nposition Nodal location, nposition, along boundary
-  virtual bool assign_cohesion_constraint(unsigned dir, int sign_n,
-                                          double cohesion, double h_min,
+  virtual bool assign_adhesion_constraint(unsigned dir, int sign_n,
+                                          double adhesion, double h_min,
                                           int nposition) = 0;
 
-  //! Apply cohesion constraints
+  //! Apply adhesion constraints
   //! \param[in] dt Time-step
-  virtual void apply_cohesion_constraints(double dt) = 0;
+  virtual void apply_adhesion_constraints(double dt) = 0;
 
   //! Apply absorbing constraint
   //! \param[in] dir Direction of p-wave propagation in model

--- a/include/solvers/mpm_base.h
+++ b/include/solvers/mpm_base.h
@@ -160,10 +160,10 @@ class MPMBase : public MPM {
   void nodal_frictional_constraints(
       const Json& mesh_prop, const std::shared_ptr<mpm::IOMesh<Tdim>>& mesh_io);
 
-  //! Nodal cohesional constraints
+  //! Nodal adhesional constraints
   //! \param[in] mesh_prop Mesh properties
   //! \param[in] mesh_io Mesh IO handle
-  void nodal_cohesional_constraints(
+  void nodal_adhesional_constraints(
       const Json& mesh_prop, const std::shared_ptr<mpm::IOMesh<Tdim>>& mesh_io);
 
   //! Nodal pressure constraints

--- a/include/solvers/mpm_base.tcc
+++ b/include/solvers/mpm_base.tcc
@@ -282,8 +282,8 @@ void mpm::MPMBase<Tdim>::initialise_mesh() {
   // Read and assign friction constraints
   this->nodal_frictional_constraints(mesh_props, mesh_io);
 
-  // Read and assign cohesion constraints
-  this->nodal_cohesional_constraints(mesh_props, mesh_io);
+  // Read and assign adhesion constraints
+  this->nodal_adhesional_constraints(mesh_props, mesh_io);
 
   // Read and assign pressure constraints
   this->nodal_pressure_constraints(mesh_props, mesh_io);
@@ -1181,29 +1181,29 @@ void mpm::MPMBase<Tdim>::nodal_frictional_constraints(
   }
 }
 
-// Nodal cohesional constraints
+// Nodal adhesional constraints
 template <unsigned Tdim>
-void mpm::MPMBase<Tdim>::nodal_cohesional_constraints(
+void mpm::MPMBase<Tdim>::nodal_adhesional_constraints(
     const Json& mesh_props, const std::shared_ptr<mpm::IOMesh<Tdim>>& mesh_io) {
   try {
-    // Read and assign cohesion constraints
+    // Read and assign adhesion constraints
     if (mesh_props.find("boundary_conditions") != mesh_props.end() &&
-        mesh_props["boundary_conditions"].find("cohesion_constraints") !=
+        mesh_props["boundary_conditions"].find("adhesion_constraints") !=
             mesh_props["boundary_conditions"].end()) {
-      // Iterate over cohesion constraints
+      // Iterate over adhesion constraints
       for (const auto& constraints :
-           mesh_props["boundary_conditions"]["cohesion_constraints"]) {
-        // Cohesion constraints are specified in a file
+           mesh_props["boundary_conditions"]["adhesion_constraints"]) {
+        // Adhesion constraints are specified in a file
         if (constraints.find("file") != constraints.end()) {
-          std::string cohesion_constraints_file =
+          std::string adhesion_constraints_file =
               constraints.at("file").template get<std::string>();
-          bool cohesion_constraints =
-              constraints_->assign_nodal_cohesion_constraints(
-                  mesh_io->read_cohesion_constraints(
-                      io_->file_name(cohesion_constraints_file)));
-          if (!cohesion_constraints)
+          bool adhesion_constraints =
+              constraints_->assign_nodal_adhesion_constraints(
+                  mesh_io->read_adhesion_constraints(
+                      io_->file_name(adhesion_constraints_file)));
+          if (!adhesion_constraints)
             throw std::runtime_error(
-                "Cohesion constraints are not properly assigned");
+                "Adhesion constraints are not properly assigned");
 
         } else {  // Entity sets
 
@@ -1213,28 +1213,28 @@ void mpm::MPMBase<Tdim>::nodal_cohesional_constraints(
           unsigned dir = constraints.at("dir").template get<unsigned>();
           // Sign of normal direction
           int sign_n = constraints.at("sign_n").template get<int>();
-          // Cohesion
-          double cohesion = constraints.at("cohesion").template get<double>();
+          // Adhesion
+          double adhesion = constraints.at("adhesion").template get<double>();
           // h_min
           double h_min = constraints.at("h_min").template get<double>();
           // nposition
           int nposition = constraints.at("nposition").template get<int>();
-          // Add cohesion constraint to mesh
-          auto cohesion_constraint = std::make_shared<mpm::CohesionConstraint>(
-              nset_id, dir, sign_n, cohesion, h_min, nposition);
-          bool cohesion_constraints =
-              constraints_->assign_nodal_cohesional_constraint(
-                  nset_id, cohesion_constraint);
-          if (!cohesion_constraints)
+          // Add adhesion constraint to mesh
+          auto adhesion_constraint = std::make_shared<mpm::AdhesionConstraint>(
+              nset_id, dir, sign_n, adhesion, h_min, nposition);
+          bool adhesion_constraints =
+              constraints_->assign_nodal_adhesional_constraint(
+                  nset_id, adhesion_constraint);
+          if (!adhesion_constraints)
             throw std::runtime_error(
-                "Nodal cohesion constraint is not properly assigned");
+                "Nodal adhesion constraint is not properly assigned");
         }
       }
     } else
-      throw std::runtime_error("Cohesion constraints JSON not found");
+      throw std::runtime_error("Adhesion constraints JSON not found");
 
   } catch (std::exception& exception) {
-    console_->warn("#{}: Cohesion conditions are undefined {} ", __LINE__,
+    console_->warn("#{}: Adhesion conditions are undefined {} ", __LINE__,
                    exception.what());
   }
 }

--- a/tests/include/write_mesh_particles.h
+++ b/tests/include/write_mesh_particles.h
@@ -24,8 +24,8 @@ bool write_json_acceleration(unsigned dim, bool resume,
 bool write_json_friction(unsigned dim, bool resume, const std::string& analysis,
                          const std::string& file_name, const unsigned dir);
 
-// Write JSON Configuration file for cohesion boundary
-bool write_json_cohesion(unsigned dim, bool resume, const std::string& analysis,
+// Write JSON Configuration file for adhesion boundary
+bool write_json_adhesion(unsigned dim, bool resume, const std::string& analysis,
                          const std::string& file_name, const unsigned dir);
 
 // Write JSON Configuration file for velocity boundary

--- a/tests/io/io_mesh_ascii_test.cc
+++ b/tests/io/io_mesh_ascii_test.cc
@@ -422,71 +422,71 @@ TEST_CASE("IOMeshAscii is checked for 2D", "[IOMesh][IOMeshAscii][2D]") {
     }
   }
 
-  SECTION("Check cohesion constraints file") {
-    // Vector of cohesion constraints
+  SECTION("Check adhesion constraints file") {
+    // Vector of adhesion constraints
     std::vector<std::tuple<mpm::Index, unsigned, int, double, double, int>>
-        cohesion_constraints;
+        adhesion_constraints;
 
     // Constraint
-    cohesion_constraints.emplace_back(std::make_tuple(0, 0, -1, 100, 0.25, 1));
-    cohesion_constraints.emplace_back(std::make_tuple(1, 0, -1, 100, 0.25, 2));
-    cohesion_constraints.emplace_back(std::make_tuple(2, 1, -1, 100, 0.25, 2));
-    cohesion_constraints.emplace_back(std::make_tuple(3, 1, -1, 100, 0.25, 1));
+    adhesion_constraints.emplace_back(std::make_tuple(0, 0, -1, 100, 0.25, 1));
+    adhesion_constraints.emplace_back(std::make_tuple(1, 0, -1, 100, 0.25, 2));
+    adhesion_constraints.emplace_back(std::make_tuple(2, 1, -1, 100, 0.25, 2));
+    adhesion_constraints.emplace_back(std::make_tuple(3, 1, -1, 100, 0.25, 1));
 
     // Dump constraints as an input file to be read
     std::ofstream file;
-    file.open("cohesion-constraints-2d.txt");
+    file.open("adhesion-constraints-2d.txt");
     // Write particle coordinates
-    for (const auto& cohesion_constraint : cohesion_constraints) {
-      file << std::get<0>(cohesion_constraint) << "\t";
-      file << std::get<1>(cohesion_constraint) << "\t";
-      file << std::get<2>(cohesion_constraint) << "\t";
-      file << std::get<3>(cohesion_constraint) << "\t";
-      file << std::get<4>(cohesion_constraint) << "\t";
-      file << std::get<5>(cohesion_constraint) << "\t";
+    for (const auto& adhesion_constraint : adhesion_constraints) {
+      file << std::get<0>(adhesion_constraint) << "\t";
+      file << std::get<1>(adhesion_constraint) << "\t";
+      file << std::get<2>(adhesion_constraint) << "\t";
+      file << std::get<3>(adhesion_constraint) << "\t";
+      file << std::get<4>(adhesion_constraint) << "\t";
+      file << std::get<5>(adhesion_constraint) << "\t";
 
       file << "\n";
     }
 
     file.close();
 
-    // Check read cohesion constraints
-    SECTION("Check cohesion constraints") {
+    // Check read adhesion constraints
+    SECTION("Check adhesion constraints") {
       // Create a read_mesh object
       auto read_mesh = std::make_unique<mpm::IOMeshAscii<dim>>();
 
       // Try to read constraints from a non-existant file
-      auto constraints = read_mesh->read_cohesion_constraints(
-          "cohesion-constraints-missing.txt");
+      auto constraints = read_mesh->read_adhesion_constraints(
+          "adhesion-constraints-missing.txt");
       // Check number of constraints
       REQUIRE(constraints.size() == 0);
 
       // Check constraints
       constraints =
-          read_mesh->read_cohesion_constraints("cohesion-constraints-2d.txt");
+          read_mesh->read_adhesion_constraints("adhesion-constraints-2d.txt");
       // Check number of particles
-      REQUIRE(constraints.size() == cohesion_constraints.size());
+      REQUIRE(constraints.size() == adhesion_constraints.size());
 
       // Check coordinates of nodes
-      for (unsigned i = 0; i < cohesion_constraints.size(); ++i) {
+      for (unsigned i = 0; i < adhesion_constraints.size(); ++i) {
         REQUIRE(
             std::get<0>(constraints.at(i)) ==
-            Approx(std::get<0>(cohesion_constraints.at(i))).epsilon(Tolerance));
+            Approx(std::get<0>(adhesion_constraints.at(i))).epsilon(Tolerance));
         REQUIRE(
             std::get<1>(constraints.at(i)) ==
-            Approx(std::get<1>(cohesion_constraints.at(i))).epsilon(Tolerance));
+            Approx(std::get<1>(adhesion_constraints.at(i))).epsilon(Tolerance));
         REQUIRE(
             std::get<2>(constraints.at(i)) ==
-            Approx(std::get<2>(cohesion_constraints.at(i))).epsilon(Tolerance));
+            Approx(std::get<2>(adhesion_constraints.at(i))).epsilon(Tolerance));
         REQUIRE(
             std::get<3>(constraints.at(i)) ==
-            Approx(std::get<3>(cohesion_constraints.at(i))).epsilon(Tolerance));
+            Approx(std::get<3>(adhesion_constraints.at(i))).epsilon(Tolerance));
         REQUIRE(
             std::get<4>(constraints.at(i)) ==
-            Approx(std::get<4>(cohesion_constraints.at(i))).epsilon(Tolerance));
+            Approx(std::get<4>(adhesion_constraints.at(i))).epsilon(Tolerance));
         REQUIRE(
             std::get<5>(constraints.at(i)) ==
-            Approx(std::get<5>(cohesion_constraints.at(i))).epsilon(Tolerance));
+            Approx(std::get<5>(adhesion_constraints.at(i))).epsilon(Tolerance));
       }
     }
   }
@@ -1370,71 +1370,71 @@ TEST_CASE("IOMeshAscii is checked for 3D", "[IOMesh][IOMeshAscii][3D]") {
     }
   }
 
-  SECTION("Check cohesion constraints file") {
-    // Vector of cohesion constraints
+  SECTION("Check adhesion constraints file") {
+    // Vector of adhesion constraints
     std::vector<std::tuple<mpm::Index, unsigned, int, double, double, int>>
-        cohesion_constraints;
+        adhesion_constraints;
 
     // Constraint
-    cohesion_constraints.emplace_back(std::make_tuple(0, 1, -1, 100, 0.25, 1));
-    cohesion_constraints.emplace_back(std::make_tuple(1, 1, -1, 100, 0.25, 2));
-    cohesion_constraints.emplace_back(std::make_tuple(2, 1, -1, 100, 0.25, 3));
-    cohesion_constraints.emplace_back(std::make_tuple(3, 2, -1, 100, 0.25, 3));
+    adhesion_constraints.emplace_back(std::make_tuple(0, 1, -1, 100, 0.25, 1));
+    adhesion_constraints.emplace_back(std::make_tuple(1, 1, -1, 100, 0.25, 2));
+    adhesion_constraints.emplace_back(std::make_tuple(2, 1, -1, 100, 0.25, 3));
+    adhesion_constraints.emplace_back(std::make_tuple(3, 2, -1, 100, 0.25, 3));
 
     // Dump constraints as an input file to be read
     std::ofstream file;
-    file.open("cohesion-constraints-3d.txt");
+    file.open("adhesion-constraints-3d.txt");
     // Write particle coordinates
-    for (const auto& cohesion_constraint : cohesion_constraints) {
-      file << std::get<0>(cohesion_constraint) << "\t";
-      file << std::get<1>(cohesion_constraint) << "\t";
-      file << std::get<2>(cohesion_constraint) << "\t";
-      file << std::get<3>(cohesion_constraint) << "\t";
-      file << std::get<4>(cohesion_constraint) << "\t";
-      file << std::get<5>(cohesion_constraint) << "\t";
+    for (const auto& adhesion_constraint : adhesion_constraints) {
+      file << std::get<0>(adhesion_constraint) << "\t";
+      file << std::get<1>(adhesion_constraint) << "\t";
+      file << std::get<2>(adhesion_constraint) << "\t";
+      file << std::get<3>(adhesion_constraint) << "\t";
+      file << std::get<4>(adhesion_constraint) << "\t";
+      file << std::get<5>(adhesion_constraint) << "\t";
 
       file << "\n";
     }
 
     file.close();
 
-    // Check read cohesion constraints
-    SECTION("Check cohesion constraints") {
+    // Check read adhesion constraints
+    SECTION("Check adhesion constraints") {
       // Create a read_mesh object
       auto read_mesh = std::make_unique<mpm::IOMeshAscii<dim>>();
 
       // Try to read constraints from a non-existant file
-      auto constraints = read_mesh->read_cohesion_constraints(
-          "cohesion-constraints-missing.txt");
+      auto constraints = read_mesh->read_adhesion_constraints(
+          "adhesion-constraints-missing.txt");
       // Check number of constraints
       REQUIRE(constraints.size() == 0);
 
       // Check constraints
       constraints =
-          read_mesh->read_cohesion_constraints("cohesion-constraints-3d.txt");
+          read_mesh->read_adhesion_constraints("adhesion-constraints-3d.txt");
       // Check number of particles
-      REQUIRE(constraints.size() == cohesion_constraints.size());
+      REQUIRE(constraints.size() == adhesion_constraints.size());
 
       // Check coordinates of nodes
-      for (unsigned i = 0; i < cohesion_constraints.size(); ++i) {
+      for (unsigned i = 0; i < adhesion_constraints.size(); ++i) {
         REQUIRE(
             std::get<0>(constraints.at(i)) ==
-            Approx(std::get<0>(cohesion_constraints.at(i))).epsilon(Tolerance));
+            Approx(std::get<0>(adhesion_constraints.at(i))).epsilon(Tolerance));
         REQUIRE(
             std::get<1>(constraints.at(i)) ==
-            Approx(std::get<1>(cohesion_constraints.at(i))).epsilon(Tolerance));
+            Approx(std::get<1>(adhesion_constraints.at(i))).epsilon(Tolerance));
         REQUIRE(
             std::get<2>(constraints.at(i)) ==
-            Approx(std::get<2>(cohesion_constraints.at(i))).epsilon(Tolerance));
+            Approx(std::get<2>(adhesion_constraints.at(i))).epsilon(Tolerance));
         REQUIRE(
             std::get<3>(constraints.at(i)) ==
-            Approx(std::get<3>(cohesion_constraints.at(i))).epsilon(Tolerance));
+            Approx(std::get<3>(adhesion_constraints.at(i))).epsilon(Tolerance));
         REQUIRE(
             std::get<4>(constraints.at(i)) ==
-            Approx(std::get<4>(cohesion_constraints.at(i))).epsilon(Tolerance));
+            Approx(std::get<4>(adhesion_constraints.at(i))).epsilon(Tolerance));
         REQUIRE(
             std::get<5>(constraints.at(i)) ==
-            Approx(std::get<5>(cohesion_constraints.at(i))).epsilon(Tolerance));
+            Approx(std::get<5>(adhesion_constraints.at(i))).epsilon(Tolerance));
       }
     }
   }

--- a/tests/io/write_mesh_particles.cc
+++ b/tests/io/write_mesh_particles.cc
@@ -435,8 +435,8 @@ bool write_json_friction(unsigned dim, bool resume, const std::string& analysis,
   return true;
 }
 
-// Write JSON Configuration file for cohesion constraint
-bool write_json_cohesion(unsigned dim, bool resume, const std::string& analysis,
+// Write JSON Configuration file for adhesion constraint
+bool write_json_adhesion(unsigned dim, bool resume, const std::string& analysis,
                          const std::string& file_name, const unsigned dir) {
   // Make json object with input files
   // 2D
@@ -472,11 +472,11 @@ bool write_json_cohesion(unsigned dim, bool resume, const std::string& analysis,
                       {"isoparametric", false},
                       {"node_type", node_type},
                       {"boundary_conditions",
-                       {{"cohesion_constraints",
+                       {{"adhesion_constraints",
                          {{{"nset_id", 1},
                            {"dir", dir},
                            {"sign_n", -1},
-                           {"cohesion", 100},
+                           {"adhesion", 100},
                            {"h_min", 0.25},
                            {"nposition", 3}}}}}},
                       {"cell_type", cell_type}}},

--- a/tests/mesh/mesh_test_2d.cc
+++ b/tests/mesh/mesh_test_2d.cc
@@ -1301,7 +1301,7 @@ TEST_CASE("Mesh is checked for 2D case", "[mesh][2D]") {
                       set_id, friction_constraint) == false);
         }
 
-        SECTION("Check assign cohesion constraints to nodes") {
+        SECTION("Check assign adhesion constraints to nodes") {
           tsl::robin_map<mpm::Index, std::vector<mpm::Index>> node_sets;
           node_sets[0] = std::vector<mpm::Index>{0, 2};
           node_sets[1] = std::vector<mpm::Index>{1, 3};
@@ -1314,40 +1314,40 @@ TEST_CASE("Mesh is checked for 2D case", "[mesh][2D]") {
           int set_id = 0;
           int dir = 0;
           int sign_n = -1;
-          double cohesion = 1000;
+          double adhesion = 1000;
           double h_min = 0.25;
           int nposition = 1;
-          // Add cohesion constraint to mesh
-          auto cohesion_constraint = std::make_shared<mpm::CohesionConstraint>(
-              set_id, dir, sign_n, cohesion, h_min, nposition);
-          REQUIRE(constraints->assign_nodal_cohesional_constraint(
-                      set_id, cohesion_constraint) == true);
+          // Add adhesion constraint to mesh
+          auto adhesion_constraint = std::make_shared<mpm::AdhesionConstraint>(
+              set_id, dir, sign_n, adhesion, h_min, nposition);
+          REQUIRE(constraints->assign_nodal_adhesional_constraint(
+                      set_id, adhesion_constraint) == true);
 
           set_id = 1;
           dir = 1;
           sign_n = -1;
-          cohesion = 1000;
+          adhesion = 1000;
           h_min = 0.25;
           nposition = 2;
-          // Add cohesion constraint to mesh
-          cohesion_constraint = std::make_shared<mpm::CohesionConstraint>(
-              set_id, dir, sign_n, cohesion, h_min, nposition);
-          REQUIRE(constraints->assign_nodal_cohesional_constraint(
-                      set_id, cohesion_constraint) == true);
+          // Add adhesion constraint to mesh
+          adhesion_constraint = std::make_shared<mpm::AdhesionConstraint>(
+              set_id, dir, sign_n, adhesion, h_min, nposition);
+          REQUIRE(constraints->assign_nodal_adhesional_constraint(
+                      set_id, adhesion_constraint) == true);
 
-          // Add cohesion constraint to all nodes in mesh
-          cohesion_constraint = std::make_shared<mpm::CohesionConstraint>(
-              1, dir, sign_n, cohesion, h_min, nposition);
-          REQUIRE(constraints->assign_nodal_cohesional_constraint(
-                      set_id, cohesion_constraint) == true);
+          // Add adhesion constraint to all nodes in mesh
+          adhesion_constraint = std::make_shared<mpm::AdhesionConstraint>(
+              1, dir, sign_n, adhesion, h_min, nposition);
+          REQUIRE(constraints->assign_nodal_adhesional_constraint(
+                      set_id, adhesion_constraint) == true);
 
           // When constraints fail
           dir = 2;
-          // Add cohesion constraint to mesh
-          cohesion_constraint = std::make_shared<mpm::CohesionConstraint>(
-              set_id, dir, sign_n, cohesion, h_min, nposition);
-          REQUIRE(constraints->assign_nodal_cohesional_constraint(
-                      set_id, cohesion_constraint) == false);
+          // Add adhesion constraint to mesh
+          adhesion_constraint = std::make_shared<mpm::AdhesionConstraint>(
+              set_id, dir, sign_n, adhesion, h_min, nposition);
+          REQUIRE(constraints->assign_nodal_adhesional_constraint(
+                      set_id, adhesion_constraint) == false);
         }
 
         // Test assign absorbing constraint
@@ -1523,31 +1523,31 @@ TEST_CASE("Mesh is checked for 2D case", "[mesh][2D]") {
                       friction_constraints) == false);
         }
 
-        // Test assign cohesion constraints to nodes
-        SECTION("Check assign cohesion constraints to nodes") {
+        // Test assign adhesion constraints to nodes
+        SECTION("Check assign adhesion constraints to nodes") {
           // Vector of particle coordinates
           std::vector<
               std::tuple<mpm::Index, unsigned, int, double, double, int>>
-              cohesion_constraints;
+              adhesion_constraints;
           //! Constraints object
           auto constraints = std::make_shared<mpm::Constraints<Dim>>(mesh);
           // Constraint
-          cohesion_constraints.emplace_back(
+          adhesion_constraints.emplace_back(
               std::make_tuple(0, 0, -1, 100, 0.25, 1));
-          cohesion_constraints.emplace_back(
+          adhesion_constraints.emplace_back(
               std::make_tuple(1, 0, -1, 100, 0.25, 2));
-          cohesion_constraints.emplace_back(
+          adhesion_constraints.emplace_back(
               std::make_tuple(2, 1, -1, 100, 0.25, 2));
-          cohesion_constraints.emplace_back(
+          adhesion_constraints.emplace_back(
               std::make_tuple(3, 1, -1, 100, 0.25, 1));
 
-          REQUIRE(constraints->assign_nodal_cohesion_constraints(
-                      cohesion_constraints) == true);
+          REQUIRE(constraints->assign_nodal_adhesion_constraints(
+                      adhesion_constraints) == true);
           // When constraints fail
-          cohesion_constraints.emplace_back(
+          adhesion_constraints.emplace_back(
               std::make_tuple(3, 2, -1, 100, 0.25, 2));
-          REQUIRE(constraints->assign_nodal_cohesion_constraints(
-                      cohesion_constraints) == false);
+          REQUIRE(constraints->assign_nodal_adhesion_constraints(
+                      adhesion_constraints) == false);
         }
 
         // Test assign pressure constraints to nodes

--- a/tests/mesh/mesh_test_3d.cc
+++ b/tests/mesh/mesh_test_3d.cc
@@ -1508,7 +1508,7 @@ TEST_CASE("Mesh is checked for 3D case", "[mesh][3D]") {
                       set_id, friction_constraint) == false);
         }
 
-        SECTION("Check assign cohesion constraints to nodes") {
+        SECTION("Check assign adhesion constraints to nodes") {
           tsl::robin_map<mpm::Index, std::vector<mpm::Index>> node_sets;
           node_sets[0] = std::vector<mpm::Index>{0, 2};
           node_sets[1] = std::vector<mpm::Index>{1, 3};
@@ -1521,40 +1521,40 @@ TEST_CASE("Mesh is checked for 3D case", "[mesh][3D]") {
           int set_id = 0;
           int dir = 0;
           int sign_n = -1;
-          double cohesion = 1000;
+          double adhesion = 1000;
           double h_min = 0.25;
           int nposition = 1;
-          // Add cohesion constraint to mesh
-          auto cohesion_constraint = std::make_shared<mpm::CohesionConstraint>(
-              set_id, dir, sign_n, cohesion, h_min, nposition);
-          REQUIRE(constraints->assign_nodal_cohesional_constraint(
-                      set_id, cohesion_constraint) == true);
+          // Add adhesion constraint to mesh
+          auto adhesion_constraint = std::make_shared<mpm::AdhesionConstraint>(
+              set_id, dir, sign_n, adhesion, h_min, nposition);
+          REQUIRE(constraints->assign_nodal_adhesional_constraint(
+                      set_id, adhesion_constraint) == true);
 
           set_id = 1;
           dir = 2;
           sign_n = -1;
-          cohesion = 1000;
+          adhesion = 1000;
           h_min = 0.25;
           nposition = 2;
-          // Add cohesion constraint to mesh
-          cohesion_constraint = std::make_shared<mpm::CohesionConstraint>(
-              set_id, dir, sign_n, cohesion, h_min, nposition);
-          REQUIRE(constraints->assign_nodal_cohesional_constraint(
-                      set_id, cohesion_constraint) == true);
+          // Add adhesion constraint to mesh
+          adhesion_constraint = std::make_shared<mpm::AdhesionConstraint>(
+              set_id, dir, sign_n, adhesion, h_min, nposition);
+          REQUIRE(constraints->assign_nodal_adhesional_constraint(
+                      set_id, adhesion_constraint) == true);
 
-          // Add cohesion constraint to all nodes in mesh
-          cohesion_constraint = std::make_shared<mpm::CohesionConstraint>(
-              1, dir, sign_n, cohesion, h_min, nposition);
-          REQUIRE(constraints->assign_nodal_cohesional_constraint(
-                      set_id, cohesion_constraint) == true);
+          // Add adhesion constraint to all nodes in mesh
+          adhesion_constraint = std::make_shared<mpm::AdhesionConstraint>(
+              1, dir, sign_n, adhesion, h_min, nposition);
+          REQUIRE(constraints->assign_nodal_adhesional_constraint(
+                      set_id, adhesion_constraint) == true);
 
           // When constraints fail
           dir = 3;
-          // Add cohesion constraint to mesh
-          cohesion_constraint = std::make_shared<mpm::CohesionConstraint>(
-              set_id, dir, sign_n, cohesion, h_min, nposition);
-          REQUIRE(constraints->assign_nodal_cohesional_constraint(
-                      set_id, cohesion_constraint) == false);
+          // Add adhesion constraint to mesh
+          adhesion_constraint = std::make_shared<mpm::AdhesionConstraint>(
+              set_id, dir, sign_n, adhesion, h_min, nposition);
+          REQUIRE(constraints->assign_nodal_adhesional_constraint(
+                      set_id, adhesion_constraint) == false);
         }
 
         // Test assign acceleration constraints to nodes
@@ -1621,31 +1621,31 @@ TEST_CASE("Mesh is checked for 3D case", "[mesh][3D]") {
                       friction_constraints) == false);
         }
 
-        // Test assign cohesion constraints to nodes
-        SECTION("Check assign cohesion constraints to nodes") {
+        // Test assign adhesion constraints to nodes
+        SECTION("Check assign adhesion constraints to nodes") {
           // Vector of particle coordinates
           std::vector<
               std::tuple<mpm::Index, unsigned, int, double, double, int>>
-              cohesion_constraints;
+              adhesion_constraints;
           //! Constraints object
           auto constraints = std::make_shared<mpm::Constraints<Dim>>(mesh);
           // Constraint
-          cohesion_constraints.emplace_back(
+          adhesion_constraints.emplace_back(
               std::make_tuple(0, 0, -1, 100, 0.25, 1));
-          cohesion_constraints.emplace_back(
+          adhesion_constraints.emplace_back(
               std::make_tuple(1, 0, -1, 100, 0.25, 2));
-          cohesion_constraints.emplace_back(
+          adhesion_constraints.emplace_back(
               std::make_tuple(2, 1, -1, 100, 0.25, 3));
-          cohesion_constraints.emplace_back(
+          adhesion_constraints.emplace_back(
               std::make_tuple(3, 2, -1, 100, 0.25, 3));
 
-          REQUIRE(constraints->assign_nodal_cohesion_constraints(
-                      cohesion_constraints) == true);
+          REQUIRE(constraints->assign_nodal_adhesion_constraints(
+                      adhesion_constraints) == true);
           // When constraints fail
-          cohesion_constraints.emplace_back(
+          adhesion_constraints.emplace_back(
               std::make_tuple(3, 3, -1, 100, 0.25, 3));
-          REQUIRE(constraints->assign_nodal_cohesion_constraints(
-                      cohesion_constraints) == false);
+          REQUIRE(constraints->assign_nodal_adhesion_constraints(
+                      adhesion_constraints) == false);
         }
 
         // Test assign absorbing constraints to nodes

--- a/tests/nodes/node_test.cc
+++ b/tests/nodes/node_test.cc
@@ -324,12 +324,12 @@ TEST_CASE("Node is checked for 1D case", "[node][1D]") {
       REQUIRE(node->assign_friction_constraint(-1, 1., 0.5) == false);
       REQUIRE(node->assign_friction_constraint(3, 1., 0.5) == false);
 
-      // Apply cohesion constraints
-      REQUIRE(node->assign_cohesion_constraint(0, -1., 1000, 0.25, 2) == true);
-      // Apply cohesion constraints
-      REQUIRE(node->assign_cohesion_constraint(-1, -1., 1000, 0.25, 2) ==
+      // Apply adhesion constraints
+      REQUIRE(node->assign_adhesion_constraint(0, -1., 1000, 0.25, 2) == true);
+      // Apply adhesion constraints
+      REQUIRE(node->assign_adhesion_constraint(-1, -1., 1000, 0.25, 2) ==
               false);
-      REQUIRE(node->assign_cohesion_constraint(3, -1., 1000, 0.25, 2) == false);
+      REQUIRE(node->assign_adhesion_constraint(3, -1., 1000, 0.25, 2) == false);
 
       // Test acceleration with constraints
       acceleration[0] = 0.5 * acceleration[0];
@@ -1084,8 +1084,8 @@ TEST_CASE("Node is checked for 2D case", "[node][2D]") {
                   Approx(acceleration(i)).epsilon(Tolerance));
       }
 
-      SECTION("Check cartesian cohesion constraints") {
-        // Case: static, cohesion fully mobilized, edge
+      SECTION("Check cartesian adhesion constraints") {
+        // Case: static, adhesion fully mobilized, edge
         // Assign mass
         mass = 100.;
         node->update_mass(false, Nphase, mass);
@@ -1096,15 +1096,15 @@ TEST_CASE("Node is checked for 2D case", "[node][2D]") {
         // Assign acceleration
         acceleration << 10., -6.;
         node->update_acceleration(false, Nphase, acceleration);
-        // Apply cohesion constraints
-        REQUIRE(node->assign_cohesion_constraint(1, -1., 1000, 0.25, 2) ==
+        // Apply adhesion constraints
+        REQUIRE(node->assign_adhesion_constraint(1, -1., 1000, 0.25, 2) ==
                 true);
         // Check out of bounds condition
-        REQUIRE(node->assign_cohesion_constraint(2, -1., 1000, 0.25, 2) ==
+        REQUIRE(node->assign_adhesion_constraint(2, -1., 1000, 0.25, 2) ==
                 false);
 
-        // Apply cohesion constraints
-        node->apply_cohesion_constraints(dt);
+        // Apply adhesion constraints
+        node->apply_adhesion_constraints(dt);
 
         // Check apply constraints
         acceleration << 7.5, -6.;
@@ -1114,16 +1114,16 @@ TEST_CASE("Node is checked for 2D case", "[node][2D]") {
         }
       }
 
-      SECTION("Check failing cohesion constraint case") {
-        // Apply cohesion constraint with incorrect nposition
-        REQUIRE(node->assign_cohesion_constraint(1, -1., 1000, 0.25, 3) ==
+      SECTION("Check failing adhesion constraint case") {
+        // Apply adhesion constraint with incorrect nposition
+        REQUIRE(node->assign_adhesion_constraint(1, -1., 1000, 0.25, 3) ==
                 false);
-        // Should throw: invalid cohesion boundary nposition
-        node->apply_cohesion_constraints(dt);
+        // Should throw: invalid adhesion boundary nposition
+        node->apply_adhesion_constraints(dt);
       }
 
-      SECTION("Check additional cohesion constraint cases") {
-        // Case: static, cohesion not fully mobilized, corner
+      SECTION("Check additional adhesion constraint cases") {
+        // Case: static, adhesion not fully mobilized, corner
         // Assign mass
         mass = 100.;
         node->update_mass(false, Nphase, mass);
@@ -1134,12 +1134,12 @@ TEST_CASE("Node is checked for 2D case", "[node][2D]") {
         // Assign acceleration
         acceleration << 1., -6.;
         node->update_acceleration(false, Nphase, acceleration);
-        // Apply cohesion constraints
-        REQUIRE(node->assign_cohesion_constraint(1, -1., 1000, 0.25, 1) ==
+        // Apply adhesion constraints
+        REQUIRE(node->assign_adhesion_constraint(1, -1., 1000, 0.25, 1) ==
                 true);
 
-        // Apply cohesion constraints
-        node->apply_cohesion_constraints(dt);
+        // Apply adhesion constraints
+        node->apply_adhesion_constraints(dt);
 
         // Check apply constraints
         acceleration << 0., -6.;
@@ -1149,8 +1149,8 @@ TEST_CASE("Node is checked for 2D case", "[node][2D]") {
         }
       }
 
-      SECTION("Check additional cohesion constraint cases") {
-        // Case: kinetic, cohesion fully mobilized, edge
+      SECTION("Check additional adhesion constraint cases") {
+        // Case: kinetic, adhesion fully mobilized, edge
         // Time step
         const double dt = 0.1;
         // Assign mass
@@ -1163,15 +1163,15 @@ TEST_CASE("Node is checked for 2D case", "[node][2D]") {
         // Assign acceleration
         acceleration << 10., -6.;
         node->update_acceleration(false, Nphase, acceleration);
-        // Apply cohesion constraints
-        REQUIRE(node->assign_cohesion_constraint(1, -1., 1000, 0.25, 2) ==
+        // Apply adhesion constraints
+        REQUIRE(node->assign_adhesion_constraint(1, -1., 1000, 0.25, 2) ==
                 true);
 
-        // Apply cohesion constraints
-        node->apply_cohesion_constraints(dt);
+        // Apply adhesion constraints
+        node->apply_adhesion_constraints(dt);
 
         // Check apply constraints
-        // vel_net=5., vel_cohesional=0.25
+        // vel_net=5., vel_adhesional=0.25
         acceleration << 7.5, -6.;
         for (unsigned i = 0; i < acceleration.size(); ++i) {
           REQUIRE(node->acceleration(Nphase)(i) ==
@@ -1179,8 +1179,8 @@ TEST_CASE("Node is checked for 2D case", "[node][2D]") {
         }
       }
 
-      SECTION("Check additional cohesion constraint cases") {
-        // Case: kinetic, cohesion not fully mobilized, edge
+      SECTION("Check additional adhesion constraint cases") {
+        // Case: kinetic, adhesion not fully mobilized, edge
         // Time step
         const double dt = 0.1;
         // Assign mass
@@ -1193,15 +1193,15 @@ TEST_CASE("Node is checked for 2D case", "[node][2D]") {
         // Assign acceleration
         acceleration << 10., -6.;
         node->update_acceleration(false, Nphase, acceleration);
-        // Apply cohesion constraints
-        REQUIRE(node->assign_cohesion_constraint(1, -1., 10000, 0.25, 2) ==
+        // Apply adhesion constraints
+        REQUIRE(node->assign_adhesion_constraint(1, -1., 10000, 0.25, 2) ==
                 true);
 
-        // Apply cohesion constraints
-        node->apply_cohesion_constraints(dt);
+        // Apply adhesion constraints
+        node->apply_adhesion_constraints(dt);
 
         // Check apply constraints
-        // vel_net=2., vel_cohesional=2.5
+        // vel_net=2., vel_adhesional=2.5
         acceleration << -10., -6.;
         for (unsigned i = 0; i < acceleration.size(); ++i) {
           REQUIRE(node->acceleration(Nphase)(i) ==
@@ -1209,8 +1209,8 @@ TEST_CASE("Node is checked for 2D case", "[node][2D]") {
         }
       }
 
-      SECTION("Check general cohesion constraints in 1 direction") {
-        // Case: static, cohesion fully mobilized, edge
+      SECTION("Check general adhesion constraints in 1 direction") {
+        // Case: static, adhesion fully mobilized, edge
         // Assign mass
         mass = 1000.;
         node->update_mass(false, Nphase, mass);
@@ -1221,8 +1221,8 @@ TEST_CASE("Node is checked for 2D case", "[node][2D]") {
         // Assign acceleration
         acceleration << 0., -9.81;
         node->update_acceleration(false, Nphase, acceleration);
-        // Apply cohesion constraints
-        REQUIRE(node->assign_cohesion_constraint(1, -1., 1000, 0.25, 2) ==
+        // Apply adhesion constraints
+        REQUIRE(node->assign_adhesion_constraint(1, -1., 1000, 0.25, 2) ==
                 true);
 
         // Apply rotation matrix with Euler angles alpha = -30 deg, beta = 0 deg
@@ -1233,8 +1233,8 @@ TEST_CASE("Node is checked for 2D case", "[node][2D]") {
         node->assign_rotation_matrix(rotation_matrix);
         const auto inverse_rotation_matrix = rotation_matrix.inverse();
 
-        // Apply general cohesion constraints
-        node->apply_cohesion_constraints(dt);
+        // Apply general adhesion constraints
+        node->apply_adhesion_constraints(dt);
 
         // Check applied constraints on acceleration in the global coordinates
         acceleration << -0.2165063509, -9.685;
@@ -1886,8 +1886,8 @@ TEST_CASE("Node is checked for 3D case", "[node][3D]") {
                   Approx(acceleration(i)).epsilon(Tolerance));
       }
 
-      SECTION("Check cartesian cohesion constraints") {
-        // Case: static, cohesion fully mobilized, face
+      SECTION("Check cartesian adhesion constraints") {
+        // Case: static, adhesion fully mobilized, face
         // Assign mass
         mass = 100.;
         node->update_mass(false, Nphase, mass);
@@ -1899,15 +1899,15 @@ TEST_CASE("Node is checked for 3D case", "[node][3D]") {
         // Assign acceleration
         acceleration << 10., -6., 0.;
         node->update_acceleration(false, Nphase, acceleration);
-        // Apply cohesion constraints
-        REQUIRE(node->assign_cohesion_constraint(1, -1., 1000, 0.25, 3) ==
+        // Apply adhesion constraints
+        REQUIRE(node->assign_adhesion_constraint(1, -1., 1000, 0.25, 3) ==
                 true);
         // Check out of bounds condition
-        REQUIRE(node->assign_cohesion_constraint(3, -1., 1000, 0.25, 3) ==
+        REQUIRE(node->assign_adhesion_constraint(3, -1., 1000, 0.25, 3) ==
                 false);
 
-        // Apply cohesion constraints
-        node->apply_cohesion_constraints(dt);
+        // Apply adhesion constraints
+        node->apply_adhesion_constraints(dt);
 
         // Check apply constraints
         // 10-0.625*(10/(10-0.625))), -6., 0.
@@ -1918,16 +1918,16 @@ TEST_CASE("Node is checked for 3D case", "[node][3D]") {
         }
       }
 
-      SECTION("Check failing cohesion constraint case") {
-        // Apply cohesion constraint with incorrect nposition
-        REQUIRE(node->assign_cohesion_constraint(1, -1., 1000, 0.25, 0) ==
+      SECTION("Check failing adhesion constraint case") {
+        // Apply adhesion constraint with incorrect nposition
+        REQUIRE(node->assign_adhesion_constraint(1, -1., 1000, 0.25, 0) ==
                 false);
-        // Should throw: invalid cohesion boundary nposition
-        node->apply_cohesion_constraints(dt);
+        // Should throw: invalid adhesion boundary nposition
+        node->apply_adhesion_constraints(dt);
       }
 
-      SECTION("Check additional cohesion constraint cases") {
-        // Case: static, cohesion not fully mobilized, edge
+      SECTION("Check additional adhesion constraint cases") {
+        // Case: static, adhesion not fully mobilized, edge
         // Assign mass
         mass = 100.;
         node->update_mass(false, Nphase, mass);
@@ -1939,12 +1939,12 @@ TEST_CASE("Node is checked for 3D case", "[node][3D]") {
         // Assign acceleration
         acceleration << 3., -6., 0.;
         node->update_acceleration(false, Nphase, acceleration);
-        // Apply cohesion constraints
-        REQUIRE(node->assign_cohesion_constraint(1, -1., 10000, 0.25, 2) ==
+        // Apply adhesion constraints
+        REQUIRE(node->assign_adhesion_constraint(1, -1., 10000, 0.25, 2) ==
                 true);
 
-        // Apply cohesion constraints
-        node->apply_cohesion_constraints(dt);
+        // Apply adhesion constraints
+        node->apply_adhesion_constraints(dt);
 
         // Check apply constraints
         acceleration << 0., -6., 0.;
@@ -1954,8 +1954,8 @@ TEST_CASE("Node is checked for 3D case", "[node][3D]") {
         }
       }
 
-      SECTION("Check additional cohesion constraint cases") {
-        // Case: kinetic, cohesion fully mobilized, corner
+      SECTION("Check additional adhesion constraint cases") {
+        // Case: kinetic, adhesion fully mobilized, corner
         // Time step
         const double dt = 0.1;
         // Assign mass
@@ -1969,15 +1969,15 @@ TEST_CASE("Node is checked for 3D case", "[node][3D]") {
         // Assign acceleration
         acceleration << 10., -6., 0.;
         node->update_acceleration(false, Nphase, acceleration);
-        // Apply cohesion constraints
-        REQUIRE(node->assign_cohesion_constraint(1, -1., 1000, 0.25, 1) ==
+        // Apply adhesion constraints
+        REQUIRE(node->assign_adhesion_constraint(1, -1., 1000, 0.25, 1) ==
                 true);
 
-        // Apply cohesion constraints
-        node->apply_cohesion_constraints(dt);
+        // Apply adhesion constraints
+        node->apply_adhesion_constraints(dt);
 
         // Check apply constraints
-        // vel_net_t=5., vel_cohesion=0.015625
+        // vel_net_t=5., vel_adhesion=0.015625
         acceleration << 9.84375, -6., 0.;
         for (unsigned i = 0; i < acceleration.size(); ++i) {
           REQUIRE(node->acceleration(Nphase)(i) ==
@@ -1985,8 +1985,8 @@ TEST_CASE("Node is checked for 3D case", "[node][3D]") {
         }
       }
 
-      SECTION("Check additional cohesion constraint cases") {
-        // Case: kinetic, cohesion not fully mobilized, edge
+      SECTION("Check additional adhesion constraint cases") {
+        // Case: kinetic, adhesion not fully mobilized, edge
         // Time step
         const double dt = 0.1;
         // Assign mass
@@ -2000,15 +2000,15 @@ TEST_CASE("Node is checked for 3D case", "[node][3D]") {
         // Assign acceleration
         acceleration << 10., -6., 0.;
         node->update_acceleration(false, Nphase, acceleration);
-        // Apply cohesion constraints
-        REQUIRE(node->assign_cohesion_constraint(1, -1., 10000, 0.25, 2) ==
+        // Apply adhesion constraints
+        REQUIRE(node->assign_adhesion_constraint(1, -1., 10000, 0.25, 2) ==
                 true);
 
-        // Apply cohesion constraints
-        node->apply_cohesion_constraints(dt);
+        // Apply adhesion constraints
+        node->apply_adhesion_constraints(dt);
 
         // Check apply constraints
-        // vel_net_t=2., vel_cohesion=3.125
+        // vel_net_t=2., vel_adhesion=3.125
         acceleration << -10., -6., 0.;
         for (unsigned i = 0; i < acceleration.size(); ++i) {
           REQUIRE(node->acceleration(Nphase)(i) ==
@@ -2016,8 +2016,8 @@ TEST_CASE("Node is checked for 3D case", "[node][3D]") {
         }
       }
 
-      SECTION("Check general cohesion constraints in 1 direction") {
-        // Case: static, cohesion fully mobilized, face
+      SECTION("Check general adhesion constraints in 1 direction") {
+        // Case: static, adhesion fully mobilized, face
         // Assign mass
         mass = 2000.;
         node->update_mass(false, Nphase, mass);
@@ -2029,8 +2029,8 @@ TEST_CASE("Node is checked for 3D case", "[node][3D]") {
         // Assign acceleration
         acceleration << 0., -9.81, 0.;
         node->update_acceleration(false, Nphase, acceleration);
-        // Apply cohesion constraints
-        REQUIRE(node->assign_cohesion_constraint(1, -1., 1000, 0.25, 3) ==
+        // Apply adhesion constraints
+        REQUIRE(node->assign_adhesion_constraint(1, -1., 1000, 0.25, 3) ==
                 true);
 
         // Apply rotation matrix with Euler angles alpha = -30 deg, beta = 0 deg
@@ -2042,8 +2042,8 @@ TEST_CASE("Node is checked for 3D case", "[node][3D]") {
         node->assign_rotation_matrix(rotation_matrix);
         const auto inverse_rotation_matrix = rotation_matrix.inverse();
 
-        // Apply general cohesion constraints
-        node->apply_cohesion_constraints(dt);
+        // Apply general adhesion constraints
+        node->apply_adhesion_constraints(dt);
 
         // Check applied constraints on acceleration in the global coordinates
         // x=x'*cos(30)+y'*sin(30), y=y'*cos(30)-x'*sin(30)

--- a/tests/nodes/node_twophase_test.cc
+++ b/tests/nodes/node_twophase_test.cc
@@ -509,11 +509,11 @@ TEST_CASE("Twophase Node is checked for 1D case", "[node][1D][2Phase]") {
       REQUIRE(node->assign_friction_constraint(-1, 1., 0.5) == false);
       REQUIRE(node->assign_friction_constraint(3, 1., 0.5) == false);
 
-      // Apply cohesion constraints
-      REQUIRE(node->assign_cohesion_constraint(0, -1., 100, 0.25, 2) == true);
-      // Apply cohesion constraints
-      REQUIRE(node->assign_cohesion_constraint(-1, -1., 100, 0.25, 2) == false);
-      REQUIRE(node->assign_cohesion_constraint(3, -1., 100, 0.25, 2) == false);
+      // Apply adhesion constraints
+      REQUIRE(node->assign_adhesion_constraint(0, -1., 100, 0.25, 2) == true);
+      // Apply adhesion constraints
+      REQUIRE(node->assign_adhesion_constraint(-1, -1., 100, 0.25, 2) == false);
+      REQUIRE(node->assign_adhesion_constraint(3, -1., 100, 0.25, 2) == false);
 
       // Test acceleration with constraints
       solid_acceleration[0] = 0.5 * solid_acceleration[0];
@@ -1660,8 +1660,8 @@ TEST_CASE("Twophase Node is checked for 2D case", "[node][2D][2Phase]") {
                   Approx(acceleration(i)).epsilon(Tolerance));
       }
 
-      SECTION("Check cartesian cohesion constraints") {
-        // Case: static, cohesion fully mobilized, edge
+      SECTION("Check cartesian adhesion constraints") {
+        // Case: static, adhesion fully mobilized, edge
         // Assign mass
         mass = 100.;
         node->update_mass(false, mpm::NodePhase::NSolid, mass);
@@ -1672,15 +1672,15 @@ TEST_CASE("Twophase Node is checked for 2D case", "[node][2D][2Phase]") {
         // Assign acceleration
         acceleration << 10., -6.;
         node->update_acceleration(false, mpm::NodePhase::NSolid, acceleration);
-        // Apply cohesion constraints
-        REQUIRE(node->assign_cohesion_constraint(1, -1., 1000, 0.25, 2) ==
+        // Apply adhesion constraints
+        REQUIRE(node->assign_adhesion_constraint(1, -1., 1000, 0.25, 2) ==
                 true);
         // Check out of bounds condition
-        REQUIRE(node->assign_cohesion_constraint(2, -1., 1000, 0.25, 2) ==
+        REQUIRE(node->assign_adhesion_constraint(2, -1., 1000, 0.25, 2) ==
                 false);
 
-        // Apply cohesion constraints
-        node->apply_cohesion_constraints(dt);
+        // Apply adhesion constraints
+        node->apply_adhesion_constraints(dt);
 
         // Check apply constraints
         acceleration << 7.5, -6.;
@@ -1690,8 +1690,8 @@ TEST_CASE("Twophase Node is checked for 2D case", "[node][2D][2Phase]") {
         }
       }
 
-      SECTION("Check general cohesion constraints in 1 direction") {
-        // Case: static, cohesion fully mobilized, edge
+      SECTION("Check general adhesion constraints in 1 direction") {
+        // Case: static, adhesion fully mobilized, edge
         // Assign mass
         mass = 1000.;
         node->update_mass(false, mpm::NodePhase::NSolid, mass);
@@ -1702,8 +1702,8 @@ TEST_CASE("Twophase Node is checked for 2D case", "[node][2D][2Phase]") {
         // Assign acceleration
         acceleration << 0., -9.81;
         node->update_acceleration(false, mpm::NodePhase::NSolid, acceleration);
-        // Apply cohesion constraints
-        REQUIRE(node->assign_cohesion_constraint(1, -1., 1000, 0.25, 2) ==
+        // Apply adhesion constraints
+        REQUIRE(node->assign_adhesion_constraint(1, -1., 1000, 0.25, 2) ==
                 true);
 
         // Apply rotation matrix with Euler angles alpha = -30 deg, beta = 0 deg
@@ -1714,8 +1714,8 @@ TEST_CASE("Twophase Node is checked for 2D case", "[node][2D][2Phase]") {
         node->assign_rotation_matrix(rotation_matrix);
         const auto inverse_rotation_matrix = rotation_matrix.inverse();
 
-        // Apply general cohesion constraints
-        node->apply_cohesion_constraints(dt);
+        // Apply general adhesion constraints
+        node->apply_adhesion_constraints(dt);
 
         // Check applied constraints on acceleration in the global coordinates
         acceleration << -0.2165063509, -9.685;
@@ -2660,8 +2660,8 @@ TEST_CASE("Twophase Node is checked for 3D case", "[node][3D][2Phase]") {
                    node->acceleration(mpm::NodePhase::NSolid))(i) ==
                   Approx(acceleration(i)).epsilon(Tolerance));
       }
-      SECTION("Check cartesian cohesion constraints") {
-        // Case: static, cohesion fully mobilized, face
+      SECTION("Check cartesian adhesion constraints") {
+        // Case: static, adhesion fully mobilized, face
         // Assign mass
         mass = 100.;
         node->update_mass(false, mpm::NodePhase::NSolid, mass);
@@ -2673,15 +2673,15 @@ TEST_CASE("Twophase Node is checked for 3D case", "[node][3D][2Phase]") {
         // Assign acceleration
         acceleration << 10., -6., 0.;
         node->update_acceleration(false, mpm::NodePhase::NSolid, acceleration);
-        // Apply cohesion constraints
-        REQUIRE(node->assign_cohesion_constraint(1, -1., 1000, 0.25, 3) ==
+        // Apply adhesion constraints
+        REQUIRE(node->assign_adhesion_constraint(1, -1., 1000, 0.25, 3) ==
                 true);
         // Check out of bounds condition
-        REQUIRE(node->assign_cohesion_constraint(3, -1., 1000, 0.25, 3) ==
+        REQUIRE(node->assign_adhesion_constraint(3, -1., 1000, 0.25, 3) ==
                 false);
 
-        // Apply cohesion constraints
-        node->apply_cohesion_constraints(dt);
+        // Apply adhesion constraints
+        node->apply_adhesion_constraints(dt);
 
         // Check apply constraints
         acceleration << 9.3333333333, -6., 0.;
@@ -2691,8 +2691,8 @@ TEST_CASE("Twophase Node is checked for 3D case", "[node][3D][2Phase]") {
         }
       }
 
-      SECTION("Check general cohesion constraints in 1 direction") {
-        // Case: static, cohesion fully mobilized, face
+      SECTION("Check general adhesion constraints in 1 direction") {
+        // Case: static, adhesion fully mobilized, face
         // Assign mass
         mass = 2000.;
         node->update_mass(false, mpm::NodePhase::NSolid, mass);
@@ -2704,8 +2704,8 @@ TEST_CASE("Twophase Node is checked for 3D case", "[node][3D][2Phase]") {
         // Assign acceleration
         acceleration << 0., -9.81, 0.;
         node->update_acceleration(false, mpm::NodePhase::NSolid, acceleration);
-        // Apply cohesion constraints
-        REQUIRE(node->assign_cohesion_constraint(1, -1., 1000, 0.25, 3) ==
+        // Apply adhesion constraints
+        REQUIRE(node->assign_adhesion_constraint(1, -1., 1000, 0.25, 3) ==
                 true);
 
         // Apply rotation matrix with Euler angles alpha = -30 deg, beta = 0 deg
@@ -2717,8 +2717,8 @@ TEST_CASE("Twophase Node is checked for 3D case", "[node][3D][2Phase]") {
         node->assign_rotation_matrix(rotation_matrix);
         const auto inverse_rotation_matrix = rotation_matrix.inverse();
 
-        // Apply general cohesion constraints
-        node->apply_cohesion_constraints(dt);
+        // Apply general adhesion constraints
+        node->apply_adhesion_constraints(dt);
 
         // Check applied constraints on acceleration in the global coordinates
         acceleration << -0.027236821, -9.7942748, 0.;

--- a/tests/solvers/mpm_explicit_constraint_adhesion_test.cc
+++ b/tests/solvers/mpm_explicit_constraint_adhesion_test.cc
@@ -7,14 +7,14 @@ using Json = nlohmann::json;
 #include "mpm_explicit.h"
 #include "write_mesh_particles.h"
 
-// Check MPM Explicit Cohesion Constraint
-TEST_CASE("MPM 2D Explicit Cohesion Constraint is checked",
-          "[MPM][2D][Explicit][Cohesion]") {
+// Check MPM Explicit Adhesion Constraint
+TEST_CASE("MPM 2D Explicit Adhesion Constraint is checked",
+          "[MPM][2D][Explicit][Adhesion]") {
   // Dimension
   const unsigned Dim = 2;
 
   // Write JSON file
-  const std::string fname = "mpm-explicit-cohesion";
+  const std::string fname = "mpm-explicit-adhesion";
   const std::string analysis = "MPMExplicit2D";
 
   // Write JSON Entity Sets file
@@ -34,13 +34,13 @@ TEST_CASE("MPM 2D Explicit Cohesion Constraint is checked",
   // clang-format off
   char* argv[] = {(char*)"./mpm",
                   (char*)"-f",  (char*)"./",
-                  (char*)"-i",  (char*)"mpm-explicit-cohesion-2d.json"};
+                  (char*)"-i",  (char*)"mpm-explicit-adhesion-2d.json"};
   // clang-format on
 
   SECTION("Check initialisation") {
     const bool resume = false;
     const unsigned dir = 1;
-    REQUIRE(mpm_test::write_json_cohesion(2, resume, analysis, fname, dir) ==
+    REQUIRE(mpm_test::write_json_adhesion(2, resume, analysis, fname, dir) ==
             true);
 
     // Create an IO object
@@ -74,14 +74,14 @@ TEST_CASE("MPM 2D Explicit Cohesion Constraint is checked",
   }
 }
 
-// Check MPM Explicit Cohesion Constraint
-TEST_CASE("MPM 3D Explicit Cohesion Constraint is checked",
-          "[MPM][3D][Explicit][Cohesion]") {
+// Check MPM Explicit Adhesion Constraint
+TEST_CASE("MPM 3D Explicit Adhesion Constraint is checked",
+          "[MPM][3D][Explicit][Adhesion]") {
   // Dimension
   const unsigned Dim = 3;
 
   // Write JSON file
-  const std::string fname = "mpm-explicit-cohesion";
+  const std::string fname = "mpm-explicit-adhesion";
   const std::string analysis = "MPMExplicit3D";
 
   // Write JSON Entity Sets file
@@ -101,13 +101,13 @@ TEST_CASE("MPM 3D Explicit Cohesion Constraint is checked",
   // clang-format off
   char* argv[] = {(char*)"./mpm",
                   (char*)"-f",  (char*)"./",
-                  (char*)"-i",  (char*)"mpm-explicit-cohesion-3d.json"};
+                  (char*)"-i",  (char*)"mpm-explicit-adhesion-3d.json"};
   // clang-format on
 
   SECTION("Check initialisation") {
     const bool resume = false;
     const unsigned dir = 1;
-    REQUIRE(mpm_test::write_json_cohesion(3, resume, analysis, fname, dir) ==
+    REQUIRE(mpm_test::write_json_adhesion(3, resume, analysis, fname, dir) ==
             true);
 
     // Create an IO object


### PR DESCRIPTION
**Description**
Small nomenclature change for boundary conditions: updated term cohesion to adhesion, as well as any related nomenclature.

**Reason**
- Terminology correction
- Make things easier to distinguish between constitutive property cohesion and boundary condition property adhesion
- Will make things consistent with levelset PR

