### PR TITLE
optional input for cauchy stress rate :adhesive_bandage: :goal_net:

### DIFF
--- a/include/solvers/mpm_base.tcc
+++ b/include/solvers/mpm_base.tcc
@@ -56,6 +56,8 @@ mpm::MPMBase<Tdim>::MPMBase(const std::shared_ptr<IO>& io) : mpm::MPM(io) {
       if (analysis_.find("stress_rate") != analysis_.end()) {
         if (analysis_["stress_rate"].template get<std::string>() == "jaumann")
           stress_rate_ = mpm::StressRate::Jaumann;
+        else if (analysis_["stress_rate"].template get<std::string>() == "none")
+          stress_rate_ = mpm::StressRate::None;
         else
           throw std::runtime_error("Stress rate type is not supported");
       } else


### PR DESCRIPTION
Added option to input "none"  for Cauchy stress rate without throwing a warning. Wiki also updated.
