### PR TITLE
Hackathon speed improvements

### DIFF
--- a/include/nodes/node.h
+++ b/include/nodes/node.h
@@ -78,6 +78,13 @@ class Node : public NodeBase<Tdim> {
   //! \param[in] mass Mass from the particles in a cell
   void update_mass(bool update, unsigned phase, double mass) noexcept override;
 
+  //! Update mass at the nodes from particle (shared)
+  //! \param[in] update A boolean to update (true) or assign (false)
+  //! \param[in] phase Index corresponding to the phase
+  //! \param[in] mass Mass from the particles in a cell
+  void shared_update_mass(bool update, unsigned phase,
+                          double mass) noexcept override;
+
   //! Return mass at a given node for a given phase
   //! \param[in] phase Index corresponding to the phase
   double mass(unsigned phase) const override { return mass_(phase); }
@@ -171,6 +178,23 @@ class Node : public NodeBase<Tdim> {
   //! \param[in] momentum Momentum from the particles in a cell
   void update_momentum(bool update, unsigned phase,
                        const VectorDim& momentum) noexcept override;
+
+  //! Update momentum at the nodes (shared)
+  //! \param[in] update A boolean to update (true) or assign (false)
+  //! \param[in] phase Index corresponding to the phase
+  //! \param[in] momentum Momentum from the particles in a cell
+  void shared_update_momentum(bool update, unsigned phase,
+                              const VectorDim& momentum) noexcept override;
+
+  //! Update mass and momentum together at nodes from particle
+  //! \param[in] update_mass A boolean to update (true) or assign (false)
+  //! \param[in] update_momentum A boolean to update (true) or assign (false)
+  //! \param[in] phase Index corresponding to the phase
+  //! \param[in] mass Mass from the particles in a cell
+  //! \param[in] momentum Momentum from the particles in a cell
+  void update_mass_momentum(bool update_mass, bool update_momentum,
+                            unsigned phase, double mass,
+                            const VectorDim& momentum) noexcept override;
 
   //! Return momentum at a given node for a given phase
   //! \param[in] phase Index corresponding to the phase

--- a/include/nodes/node.tcc
+++ b/include/nodes/node.tcc
@@ -64,6 +64,33 @@ void mpm::Node<Tdim, Tdof, Tnphases>::update_mass(bool update, unsigned phase,
   node_mutex_.unlock();
 }
 
+//! Update mass at the nodes from particle (shared)
+template <unsigned Tdim, unsigned Tdof, unsigned Tnphases>
+void mpm::Node<Tdim, Tdof, Tnphases>::shared_update_mass(bool update,
+                                                         unsigned phase,
+                                                         double mass) noexcept {
+  // Decide to update or assign
+  const double factor = (update == true) ? 1. : 0.;
+
+  // Update/assign mass
+  mass_(phase) = (mass_(phase) * factor) + mass;
+}
+
+//! Update mass and momentum together at nodes from particle
+template <unsigned Tdim, unsigned Tdof, unsigned Tnphases>
+void mpm::Node<Tdim, Tdof, Tnphases>::update_mass_momentum(
+    bool update_mass, bool update_momentum, unsigned phase, double mass,
+    const Eigen::Matrix<double, Tdim, 1>& momentum) noexcept {
+  // Assert
+  assert(phase < Tnphases);
+
+  // Update/assign mass and momentum
+  node_mutex_.lock();
+  shared_update_mass(update_mass, phase, mass);
+  shared_update_momentum(update_momentum, phase, momentum);
+  node_mutex_.unlock();
+}
+
 //! Update volume at the nodes from particle
 template <unsigned Tdim, unsigned Tdof, unsigned Tnphases>
 void mpm::Node<Tdim, Tdof, Tnphases>::update_volume(bool update, unsigned phase,
@@ -159,6 +186,18 @@ void mpm::Node<Tdim, Tdof, Tnphases>::update_momentum(
   node_mutex_.lock();
   momentum_.col(phase) = momentum_.col(phase) * factor + momentum;
   node_mutex_.unlock();
+}
+
+//! Assign nodal momentum (shared)
+template <unsigned Tdim, unsigned Tdof, unsigned Tnphases>
+void mpm::Node<Tdim, Tdof, Tnphases>::shared_update_momentum(
+    bool update, unsigned phase,
+    const Eigen::Matrix<double, Tdim, 1>& momentum) noexcept {
+  // Decide to update or assign
+  const double factor = (update == true) ? 1. : 0.;
+
+  // Update/assign momentum
+  momentum_.col(phase) = momentum_.col(phase) * factor + momentum;
 }
 
 //! Update pressure at the nodes from particle

--- a/include/nodes/node_base.h
+++ b/include/nodes/node_base.h
@@ -92,6 +92,13 @@ class NodeBase {
   virtual void update_mass(bool update, unsigned phase,
                            double mass) noexcept = 0;
 
+  //! Update mass at the nodes from particle (shared)
+  //! \param[in] update A boolean to update (true) or assign (false)
+  //! \param[in] phase Index corresponding to the phase
+  //! \param[in] mass Mass from the particles in a cell
+  virtual void shared_update_mass(bool update, unsigned phase,
+                                  double mass) noexcept = 0;
+
   //! Return mass at a given node for a given phase
   virtual double mass(unsigned phase) const = 0;
 
@@ -171,6 +178,23 @@ class NodeBase {
   //! \param[in] momentum Momentum from the particles in a cell
   virtual void update_momentum(bool update, unsigned phase,
                                const VectorDim& momentum) noexcept = 0;
+
+  //! Update nodal momentum (shared)
+  //! \param[in] update A boolean to update (true) or assign (false)
+  //! \param[in] phase Index corresponding to the phase
+  //! \param[in] momentum Momentum from the particles in a cell
+  virtual void shared_update_momentum(bool update, unsigned phase,
+                                      const VectorDim& momentum) noexcept = 0;
+
+  //! Update mass and momentum together at nodes from particle
+  //! \param[in] update_mass A boolean to update (true) or assign (false)
+  //! \param[in] update_momentum A boolean to update (true) or assign (false)
+  //! \param[in] phase Index corresponding to the phase
+  //! \param[in] mass Mass from the particles in a cell
+  //! \param[in] momentum Momentum from the particles in a cell
+  virtual void update_mass_momentum(bool update_mass, bool update_momentum,
+                                    unsigned phase, double mass,
+                                    const VectorDim& momentum) noexcept = 0;
 
   //! Return momentum
   //! \param[in] phase Index corresponding to the phase

--- a/include/particles/particle.tcc
+++ b/include/particles/particle.tcc
@@ -643,10 +643,9 @@ void mpm::Particle<Tdim>::map_mass_momentum_to_nodes(
       // Map mass and momentum to nodes
       for (unsigned i = 0; i < nodes_.size(); ++i) {
         // Map mass and momentum
-        nodes_[i]->update_mass(true, mpm::ParticlePhase::Solid,
-                               mass_ * shapefn_[i]);
-        nodes_[i]->update_momentum(true, mpm::ParticlePhase::Solid,
-                                   mass_ * shapefn_[i] * velocity_);
+        nodes_[i]->update_mass_momentum(true, true, mpm::ParticlePhase::Solid,
+                                        mass_ * shapefn_[i],
+                                        mass_ * shapefn_[i] * velocity_);
       }
       break;
   }
@@ -682,10 +681,9 @@ void mpm::Particle<Tdim>::map_mass_momentum_to_nodes_affine() noexcept {
                               (nodes_[i]->coordinates() - this->coordinates_);
 
     // Map mass and momentum
-    nodes_[i]->update_mass(true, mpm::ParticlePhase::Solid,
-                           mass_ * shapefn_[i]);
-    nodes_[i]->update_momentum(true, mpm::ParticlePhase::Solid,
-                               mass_ * shapefn_[i] * map_velocity);
+    nodes_[i]->update_mass_momentum(true, true, mpm::ParticlePhase::Solid,
+                                    mass_ * shapefn_[i],
+                                    mass_ * shapefn_[i] * map_velocity);
   }
 }
 
@@ -709,10 +707,9 @@ void mpm::Particle<Tdim>::map_mass_momentum_to_nodes_taylor() noexcept {
         mapping_matrix_ * (nodes_[i]->coordinates() - this->coordinates_);
 
     // Map mass and momentum
-    nodes_[i]->update_mass(true, mpm::ParticlePhase::Solid,
-                           mass_ * shapefn_[i]);
-    nodes_[i]->update_momentum(true, mpm::ParticlePhase::Solid,
-                               mass_ * shapefn_[i] * map_velocity);
+    nodes_[i]->update_mass_momentum(true, true, mpm::ParticlePhase::Solid,
+                                    mass_ * shapefn_[i],
+                                    mass_ * shapefn_[i] * map_velocity);
   }
 }
 

--- a/include/particles/particle_twophase.tcc
+++ b/include/particles/particle_twophase.tcc
@@ -398,10 +398,9 @@ void mpm::TwoPhaseParticle<Tdim>::map_liquid_mass_momentum_to_nodes() noexcept {
 
   // Map liquid mass and momentum to nodes
   for (unsigned i = 0; i < nodes_.size(); ++i) {
-    nodes_[i]->update_mass(true, mpm::ParticlePhase::Liquid,
-                           liquid_mass_ * shapefn_[i]);
-    nodes_[i]->update_momentum(true, mpm::ParticlePhase::Liquid,
-                               liquid_mass_ * shapefn_[i] * liquid_velocity_);
+    nodes_[i]->update_mass_momentum(
+        true, true, mpm::ParticlePhase::Liquid, liquid_mass_ * shapefn_[i],
+        liquid_mass_ * shapefn_[i] * liquid_velocity_);
   }
 }
 


### PR DESCRIPTION
PR for computational speed improvements during hackathon.

**Description**
- Refactor for updating mass and momentum within single loop & mutex (previous separate update functions still available). Fixes CPU idle time every step when using OpenMP.

