### PR TITLE
[IO] VTK Outputs - id, materials, geometry (optional)

### DIFF
--- a/include/particles/particle.tcc
+++ b/include/particles/particle.tcc
@@ -327,6 +327,10 @@ void mpm::Particle<Tdim>::initialise() {
   deformation_gradient_increment_.setIdentity();
 
   // Initialize scalar, vector, and tensor data properties
+  this->scalar_properties_["id"] = [&]() { return static_cast<double>(id_); };
+  this->scalar_properties_["material"] = [&]() {
+    return static_cast<double>(material_id_[mpm::ParticlePhase::Solid]);
+  };
   this->scalar_properties_["mass"] = [&]() { return mass(); };
   this->scalar_properties_["volume"] = [&]() { return volume(); };
   this->scalar_properties_["mass_density"] = [&]() { return mass_density(); };

--- a/include/solvers/mpm_base.h
+++ b/include/solvers/mpm_base.h
@@ -276,6 +276,8 @@ class MPMBase : public MPM {
   std::map<unsigned, std::shared_ptr<mpm::Material<Tdim>>> materials_;
   //! Mathematical functions
   std::map<unsigned, std::shared_ptr<mpm::FunctionBase>> math_functions_;
+  //! VTK geometry output bool
+  bool geometry_vtk_{false};
   //! VTK particle variables
   tsl::robin_map<mpm::VariableType, std::vector<std::string>> vtk_vars_;
   //! VTK state variables

--- a/include/solvers/mpm_base.tcc
+++ b/include/solvers/mpm_base.tcc
@@ -24,6 +24,8 @@ mpm::MPMBase<Tdim>::MPMBase(const std::shared_ptr<IO>& io) : mpm::MPM(io) {
   // Variable list
   tsl::robin_map<std::string, VariableType> variables = {
       // Scalar variables
+      {"id", VariableType::Scalar},
+      {"material", VariableType::Scalar},
       {"mass", VariableType::Scalar},
       {"volume", VariableType::Scalar},
       {"mass_density", VariableType::Scalar},
@@ -156,7 +158,9 @@ mpm::MPMBase<Tdim>::MPMBase(const std::shared_ptr<IO>& io) : mpm::MPM(io) {
     for (unsigned i = 0; i < post_process_.at("vtk").size(); ++i) {
       std::string attribute =
           post_process_["vtk"][i].template get<std::string>();
-      if (variables.find(attribute) != variables.end())
+      if (attribute == "geometry")
+        geometry_vtk_ = true;
+      else if (variables.find(attribute) != variables.end())
         vtk_vars_[variables.at(attribute)].emplace_back(attribute);
       else {
         console_->warn(
@@ -582,20 +586,22 @@ void mpm::MPMBase<Tdim>::write_vtk(mpm::Index step, mpm::Index max_steps) {
 
   // VTK PolyData writer
   auto vtk_writer = std::make_unique<VtkWriter>(mesh_->particle_coordinates());
+  const std::string extension = ".vtp";
 
   // Write mesh on step 0
   // Get active node pairs use true
   if (step % nload_balance_steps_ == 0)
     vtk_writer->write_mesh(
-        io_->output_file("mesh", ".vtp", uuid_, step, max_steps).string(),
+        io_->output_file("mesh", extension, uuid_, step, max_steps).string(),
         mesh_->nodal_coordinates(), mesh_->node_pairs(true));
 
-  // Write input geometry to vtk file
-  const std::string extension = ".vtp";
-  const std::string attribute = "geometry";
-  auto meshfile =
-      io_->output_file(attribute, extension, uuid_, step, max_steps).string();
-  vtk_writer->write_geometry(meshfile);
+  // VTK geometry
+  if (geometry_vtk_) {
+    auto meshfile =
+        io_->output_file("geometry", extension, uuid_, step, max_steps)
+            .string();
+    vtk_writer->write_geometry(meshfile);
+  }
 
   // MPI parallel vtk file
   int mpi_rank = 0;

--- a/tests/io/write_mesh_particles.cc
+++ b/tests/io/write_mesh_particles.cc
@@ -613,7 +613,7 @@ bool write_json_adhesion(unsigned dim, bool resume, const std::string& analysis,
                       {"nload_balance_steps", 1000}}},
                     {"post_processing",
                      {{"path", "results/"},
-                      {"vtk", {"stresses", "strains", "velocities"}},
+                      {"vtk", {"geometry", "id", "material"}},
                       {"output_steps", 5}}}};
 
   // Dump JSON as an input file to be read

--- a/tests/particles/particle_test.cc
+++ b/tests/particles/particle_test.cc
@@ -123,6 +123,9 @@ TEST_CASE("Particle is checked for 1D case", "[particle][1D]") {
     std::shared_ptr<mpm::ParticleBase<Dim>> particle =
         std::make_shared<mpm::Particle<Dim>>(id, coords, status);
 
+    // Check scalar data: ID
+    REQUIRE(particle->scalar_data("id") == 0);
+
     // Check scalar data: mass
     REQUIRE(particle->scalar_data("mass") == Approx(0.0).epsilon(Tolerance));
     double mass = 100.5;
@@ -573,11 +576,35 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
     REQUIRE(particle->id() == 0);
   }
 
+  //! Check id is a positive value
   SECTION("Particle id is positive") {
-    //! Check for id is a positive value
     mpm::Index id = std::numeric_limits<mpm::Index>::max();
     auto particle = std::make_shared<mpm::Particle<Dim>>(id, coords);
     REQUIRE(particle->id() == std::numeric_limits<mpm::Index>::max());
+  }
+
+  //! Test particles scalar, vector and tensor data
+  SECTION("Check particle scalar, vector, and tensor data") {
+    mpm::Index id = 0;
+    const double Tolerance = 1.E-7;
+    bool status = true;
+    std::shared_ptr<mpm::ParticleBase<Dim>> particle =
+        std::make_shared<mpm::Particle<Dim>>(id, coords, status);
+
+    // Assign material
+    unsigned mid = 42;
+    // Initialise material
+    Json jmaterial;
+    jmaterial["density"] = 1000.;
+    jmaterial["youngs_modulus"] = 1.0E+7;
+    jmaterial["poisson_ratio"] = 0.3;
+
+    auto material =
+        Factory<mpm::Material<Dim>, unsigned, const Json&>::instance()->create(
+            "LinearElastic2D", std::move(mid), jmaterial);
+
+    // Assign material properties
+    REQUIRE(particle->assign_material(material) == true);
   }
 
   //! Test coordinates function


### PR DESCRIPTION
**Description**
VTK (.vtp) output options edited:
- "id" option for particle ID.
- "material" option for material ID (solid phase only).
- "geometry" option is now available, otherwise geometry no longer outputs (previously was output by default).

**TODO**
- [x] Single-phase test for 2D column collapse.
- [x] Write tests.
- [x] Update wiki.