### PR TITLE
[Constitutive] Fixing issues with volume expansion in Mohr-Coulomb model

### DIFF
--- a/include/materials/infinitesimal_strain/mohr_coulomb.h
+++ b/include/materials/infinitesimal_strain/mohr_coulomb.h
@@ -129,10 +129,8 @@ class MohrCoulomb : public InfinitesimalElastoPlastic<Tdim> {
   double density_{std::numeric_limits<double>::max()};
   //! Grain density
   double grain_density_{std::numeric_limits<double>::max()};
-  //! Initial packing fraction
-  double initial_packing_fraction_{std::numeric_limits<double>::max()};
   //! Minimum packing fraction
-  double minimum_packing_fraction_{0.0};
+  double minimum_packing_fraction_{0.45};
 
   //! Youngs modulus
   double youngs_modulus_{std::numeric_limits<double>::max()};

--- a/include/materials/infinitesimal_strain/mohr_coulomb.h
+++ b/include/materials/infinitesimal_strain/mohr_coulomb.h
@@ -130,7 +130,7 @@ class MohrCoulomb : public InfinitesimalElastoPlastic<Tdim> {
   //! Grain density
   double grain_density_{std::numeric_limits<double>::max()};
   //! Minimum packing fraction
-  double minimum_packing_fraction_{0.45};
+  double minimum_packing_fraction_{0.0};
 
   //! Youngs modulus
   double youngs_modulus_{std::numeric_limits<double>::max()};

--- a/include/materials/infinitesimal_strain/mohr_coulomb.h
+++ b/include/materials/infinitesimal_strain/mohr_coulomb.h
@@ -13,7 +13,7 @@ namespace mpm {
 
 namespace mohrcoulomb {
 //! Failure state
-enum FailureState { Elastic = 0, Shear = 1, Tensile = 2 };
+enum FailureState { Elastic = 0, Shear = 1, Tensile = 2, Separated = 3 };
 }  // namespace mohrcoulomb
 
 //! MohrCoulomb class
@@ -127,6 +127,13 @@ class MohrCoulomb : public InfinitesimalElastoPlastic<Tdim> {
 
   //! Density
   double density_{std::numeric_limits<double>::max()};
+  //! Grain density
+  double grain_density_{std::numeric_limits<double>::max()};
+  //! Initial packing fraction
+  double initial_packing_fraction_{std::numeric_limits<double>::max()};
+  //! Minimum packing fraction
+  double minimum_packing_fraction_{0.0};
+
   //! Youngs modulus
   double youngs_modulus_{std::numeric_limits<double>::max()};
   //! Bulk modulus
@@ -159,7 +166,8 @@ class MohrCoulomb : public InfinitesimalElastoPlastic<Tdim> {
   std::map<int, mpm::mohrcoulomb::FailureState> yield_type_ = {
       {0, mpm::mohrcoulomb::FailureState::Elastic},
       {1, mpm::mohrcoulomb::FailureState::Shear},
-      {2, mpm::mohrcoulomb::FailureState::Tensile}};
+      {2, mpm::mohrcoulomb::FailureState::Tensile},
+      {3, mpm::mohrcoulomb::FailureState::Separated}};
 };  // MohrCoulomb class
 }  // namespace mpm
 

--- a/include/materials/infinitesimal_strain/mohr_coulomb.tcc
+++ b/include/materials/infinitesimal_strain/mohr_coulomb.tcc
@@ -390,8 +390,8 @@ Eigen::Matrix<double, 6, 1> mpm::MohrCoulomb<Tdim>::compute_stress(
       this->compute_trial_stress(stress, dstrain, de, ptr, state_vars);
   // Separated state: current packing density is less than critical density
   if (current_packing_density <= critical_density) {
-    const double tau_tr = mpm::materials::q(trial_stress) / sqrt(3.0);
-    (*state_vars).at("pdstrain") += tau_tr / shear_modulus_;
+    (*state_vars).at("pdstrain") +=
+        mpm::materials::q(trial_stress) / 3.0 / shear_modulus_;
     (*state_vars).at("yield_state") = 3;
     return Vector6d::Zero();
   }

--- a/include/materials/infinitesimal_strain/mohr_coulomb.tcc
+++ b/include/materials/infinitesimal_strain/mohr_coulomb.tcc
@@ -9,25 +9,29 @@ mpm::MohrCoulomb<Tdim>::MohrCoulomb(unsigned id,
     density_ = material_properties.at("density").template get<double>();
 
     // Initial Packing Fraction
+    double initial_packing_fraction = 1.;
     if (material_properties.contains("packing_fraction"))
-      initial_packing_fraction_ =
+      initial_packing_fraction =
           material_properties.at("packing_fraction").template get<double>();
     else if (material_properties.contains("porosity"))
-      initial_packing_fraction_ =
+      initial_packing_fraction =
           1. - material_properties.at("porosity").template get<double>();
 
     // Solid grain density
     bool is_wet = false;
-    if (material_properties.contains("is_wet"))
-      is_wet = material_properties.at("is_wet").template get<bool>();
-    else if (material_properties.contains("porosity"))
+    // Check if two-phase simulation is considered
+    if (material_properties.contains("porosity") &&
+        (material_properties.contains("k_x") ||
+         material_properties.contains("k_y") ||
+         material_properties.contains("k_z")))
       is_wet = true;
     if (!is_wet)
-      grain_density_ = density_ / initial_packing_fraction_;
+      grain_density_ = density_ / initial_packing_fraction;
     else
       grain_density_ = density_;
 
     // Minimum packing fraction
+    minimum_packing_fraction_ = 0.45;
     if (material_properties.contains("packing_fraction_minimum"))
       minimum_packing_fraction_ =
           material_properties.at("packing_fraction_minimum")

--- a/include/materials/infinitesimal_strain/mohr_coulomb.tcc
+++ b/include/materials/infinitesimal_strain/mohr_coulomb.tcc
@@ -7,6 +7,32 @@ mpm::MohrCoulomb<Tdim>::MohrCoulomb(unsigned id,
     // General parameters
     // Density
     density_ = material_properties.at("density").template get<double>();
+
+    // Initial Packing Fraction
+    if (material_properties.contains("packing_fraction"))
+      initial_packing_fraction_ =
+          material_properties.at("packing_fraction").template get<double>();
+    else if (material_properties.contains("porosity"))
+      initial_packing_fraction_ =
+          1. - material_properties.at("porosity").template get<double>();
+
+    // Solid grain density
+    bool is_wet = false;
+    if (material_properties.contains("is_wet"))
+      is_wet = material_properties.at("is_wet").template get<bool>();
+    else if (material_properties.contains("porosity"))
+      is_wet = true;
+    if (!is_wet)
+      grain_density_ = density_ / initial_packing_fraction_;
+    else
+      grain_density_ = density_;
+
+    // Minimum packing fraction
+    if (material_properties.contains("packing_fraction_minimum"))
+      minimum_packing_fraction_ =
+          material_properties.at("packing_fraction_minimum")
+              .template get<double>();
+
     // Young's modulus
     youngs_modulus_ =
         material_properties.at("youngs_modulus").template get<double>();
@@ -129,7 +155,7 @@ typename mpm::mohrcoulomb::FailureState
           ((sin(theta + M_PI / 3.) / (std::sqrt(3.) * cos(phi))) +
            (cos(theta + M_PI / 3.) * tan(phi) / 3.)) +
       (epsilon / std::sqrt(3.)) * tan(phi) - cohesion;
-  // Initialise yield status (0: elastic, 1: tension failure, 2: shear failure)
+  // Initialise yield status (0: elastic, 1: shear failure, 2: tensile failure)
   auto yield_type = mpm::mohrcoulomb::FailureState::Elastic;
   // Check for tension and shear
   if ((*yield_function)(0) > Tolerance && (*yield_function)(1) > Tolerance) {
@@ -318,6 +344,11 @@ template <unsigned Tdim>
 Eigen::Matrix<double, 6, 1> mpm::MohrCoulomb<Tdim>::compute_stress(
     const Vector6d& stress, const Vector6d& dstrain,
     const ParticleBase<Tdim>* ptr, mpm::dense_map* state_vars, double dt) {
+
+  // Density and packing parameters
+  const double current_packing_density = ptr->mass_density();
+  const double critical_density = minimum_packing_fraction_ * grain_density_;
+
   // Get previous time step state variable
   const auto prev_state_vars = (*state_vars);
   const double pdstrain = (*state_vars).at("pdstrain");
@@ -359,6 +390,13 @@ Eigen::Matrix<double, 6, 1> mpm::MohrCoulomb<Tdim>::compute_stress(
   Eigen::Matrix<double, 2, 1> yield_function_trial;
   auto yield_type_trial =
       this->compute_yield_state(&yield_function_trial, (*state_vars));
+  // Separated state: current packing density is less than critical density
+  if (current_packing_density <= critical_density) {
+    const double tau_tr = mpm::materials::q(trial_stress) / sqrt(3.0);
+    (*state_vars).at("pdstrain") += tau_tr / shear_modulus_;
+    (*state_vars).at("yield_state") = 3;
+    return Vector6d::Zero();
+  }
   // Return the updated stress in elastic state
   if (yield_type_trial == mpm::mohrcoulomb::FailureState::Elastic) {
     (*state_vars).at("yield_state") = 0;
@@ -504,6 +542,11 @@ Eigen::Matrix<double, 6, 6>
   const Matrix6x6 de = this->compute_elastic_tensor(state_vars);
   if (yield_type == mpm::mohrcoulomb::FailureState::Elastic) {
     return de;
+  }
+
+  // Return zero tensor matrix in separated state
+  if (yield_type == mpm::mohrcoulomb::FailureState::Separated) {
+    return Matrix6x6::Zero();
   }
 
   //! Elasto-plastic stiffness matrix

--- a/include/particles/particle.h
+++ b/include/particles/particle.h
@@ -175,8 +175,13 @@ class Particle : public ParticleBase<Tdim> {
     return strain_rate_;
   };
 
-  //! Return dvolumetric strain of centroid
-  //! \retval dvolumetric strain at centroid
+  //! Assign dvolumetric strain
+  void assign_dvolumetric_strain(double dvol_strain) noexcept override {
+    dvolumetric_strain_ = dvol_strain;
+  }
+
+  //! Return dvolumetric strain
+  //! \retval dvolumetric strain
   double dvolumetric_strain() const override { return dvolumetric_strain_; }
 
   //! Assign deformation gradient increment

--- a/include/particles/particle_base.h
+++ b/include/particles/particle_base.h
@@ -239,6 +239,9 @@ class ParticleBase {
   //! Strain rate
   virtual Eigen::Matrix<double, 6, 1> strain_rate() const = 0;
 
+  //! Assign dvolumetric strain
+  virtual void assign_dvolumetric_strain(double dvol_strain) noexcept = 0;
+
   //! dvolumetric strain
   virtual double dvolumetric_strain() const = 0;
 

--- a/tests/materials/mohr_coulomb_test.cc
+++ b/tests/materials/mohr_coulomb_test.cc
@@ -146,6 +146,46 @@ TEST_CASE("MohrCoulomb is checked in 2D (cohesion only, without softening)",
 
     REQUIRE(material->id() == 0);
 
+    // Coordinates of nodes for the cell
+    mpm::Index cell_id = 0;
+    const unsigned Dof = 2;
+    const unsigned Nphases = 1;
+    const unsigned Nnodes = 4;
+
+    coords << -2, -2;
+    std::shared_ptr<mpm::NodeBase<Dim>> node0 =
+        std::make_shared<mpm::Node<Dim, Dof, Nphases>>(0, coords);
+    coords << 2, -2;
+    std::shared_ptr<mpm::NodeBase<Dim>> node1 =
+        std::make_shared<mpm::Node<Dim, Dof, Nphases>>(1, coords);
+    coords << 2, 2;
+    std::shared_ptr<mpm::NodeBase<Dim>> node2 =
+        std::make_shared<mpm::Node<Dim, Dof, Nphases>>(2, coords);
+    coords << -2, 2;
+    std::shared_ptr<mpm::NodeBase<Dim>> node3 =
+        std::make_shared<mpm::Node<Dim, Dof, Nphases>>(3, coords);
+
+    std::shared_ptr<mpm::Element<Dim>> shapefn =
+        Factory<mpm::Element<Dim>>::instance()->create("ED2Q4");
+
+    node0->assign_velocity_constraint(0, 0.02);
+    node0->assign_velocity_constraint(1, 0.03);
+    node0->apply_velocity_constraints();
+
+    auto cell = std::make_shared<mpm::Cell<Dim>>(cell_id, Nnodes, shapefn);
+
+    cell->add_node(0, node0);
+    cell->add_node(1, node1);
+    cell->add_node(2, node2);
+    cell->add_node(3, node3);
+
+    // Initialise cell
+    REQUIRE(cell->initialise() == true);
+    // Check if cell is initialised, after addition of nodes
+    REQUIRE(cell->is_initialised() == true);
+
+    particle->assign_cell(cell);
+
     // Assign particle mass and volume
     particle->assign_volume(1.0);
     particle->assign_material(mohr_coulomb, 0);

--- a/tests/materials/mohr_coulomb_test.cc
+++ b/tests/materials/mohr_coulomb_test.cc
@@ -46,6 +46,7 @@ TEST_CASE("MohrCoulomb is checked in 2D (cohesion only, without softening)",
   jmaterial["residual_pdstrain"] = 0.;
   jmaterial["tension_cutoff"] = 0.;
   jmaterial["packing_fraction"] = 0.6;
+  jmaterial["packing_fraction_minimum"] = 0.4;
 
   //! Check for id = 0
   SECTION("MohrCoulomb id is zero") {
@@ -688,6 +689,7 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi, without softening)",
   jmaterial["residual_pdstrain"] = 0.;
   jmaterial["tension_cutoff"] = 0.;
   jmaterial["packing_fraction"] = 0.6;
+  jmaterial["packing_fraction_minimum"] = 0.4;
 
   //! Check yield correction based on trial stress
   SECTION("MohrCoulomb check yield correction based on trial stress") {
@@ -1239,7 +1241,7 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi & psi, without softening)",
   jmaterial["peak_pdstrain"] = 0.;
   jmaterial["residual_pdstrain"] = 0.;
   jmaterial["tension_cutoff"] = 0.;
-  jmaterial["packing_fraction"] = 0.6;
+  jmaterial["porosity"] = 0.4;
 
   //! Check yield correction based on trial stress
   SECTION("MohrCoulomb check yield correction based on trial stress") {
@@ -1787,7 +1789,9 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi & psi, with softening)",
   jmaterial["peak_pdstrain"] = 0.;
   jmaterial["residual_pdstrain"] = 0.001;
   jmaterial["tension_cutoff"] = 0.;
-  jmaterial["packing_fraction"] = 0.6;
+  jmaterial["porosity"] = 0.4;
+  jmaterial["kx"] = 5.e-6;
+  jmaterial["ky"] = 5.e-6;
 
   //! Check yield correction based on trial stress
   SECTION("MohrCoulomb check yield correction based on trial stress") {
@@ -2934,7 +2938,7 @@ TEST_CASE("MohrCoulomb is checked in 3D (c & phi & psi, with softening)",
   jmaterial["peak_pdstrain"] = 1.E-16;
   jmaterial["residual_pdstrain"] = 0.001;
   jmaterial["tension_cutoff"] = 0.;
-  jmaterial["packing_fraction"] = 0.6;
+  jmaterial["porosity"] = 0.4;
 
   //! Check yield correction based on trial stress
   SECTION("MohrCoulomb check yield correction based on trial stress") {

--- a/tests/materials/mohr_coulomb_test.cc
+++ b/tests/materials/mohr_coulomb_test.cc
@@ -11,7 +11,6 @@
 #include "mohr_coulomb.h"
 #include "node.h"
 #include "particle.h"
-#include <iostream>
 
 //! Check MohrCoulomb class in 2D
 //! Cohesion only, without softening
@@ -379,9 +378,6 @@ TEST_CASE("MohrCoulomb is checked in 2D (cohesion only, without softening)",
 
       // Initialise elastic state
       material->initialise(&state_variables);
-
-      std::cout << "PARTICLE_MASS_DENSITY: " << particle->mass_density()
-                << std::endl;
 
       // Check compute stress
       mpm::Material<Dim>::Vector6d updated_stress =

--- a/tests/materials/mohr_coulomb_test.cc
+++ b/tests/materials/mohr_coulomb_test.cc
@@ -11,6 +11,7 @@
 #include "mohr_coulomb.h"
 #include "node.h"
 #include "particle.h"
+#include <iostream>
 
 //! Check MohrCoulomb class in 2D
 //! Cohesion only, without softening
@@ -44,6 +45,7 @@ TEST_CASE("MohrCoulomb is checked in 2D (cohesion only, without softening)",
   jmaterial["peak_pdstrain"] = 0.;
   jmaterial["residual_pdstrain"] = 0.;
   jmaterial["tension_cutoff"] = 0.;
+  jmaterial["packing_fraction"] = 0.6;
 
   //! Check for id = 0
   SECTION("MohrCoulomb id is zero") {
@@ -104,6 +106,8 @@ TEST_CASE("MohrCoulomb is checked in 2D (cohesion only, without softening)",
             Approx(jmaterial["cohesion"]).epsilon(Tolerance));
     REQUIRE(material->template property<double>("tension_cutoff") ==
             Approx(jmaterial["tension_cutoff"]).epsilon(Tolerance));
+    REQUIRE(material->template property<double>("packing_fraction") ==
+            Approx(jmaterial["packing_fraction"]).epsilon(Tolerance));
 
     // Check if state variable is initialised
     SECTION("State variable is initialised") {
@@ -141,6 +145,11 @@ TEST_CASE("MohrCoulomb is checked in 2D (cohesion only, without softening)",
     auto mohr_coulomb = std::make_shared<mpm::MohrCoulomb<Dim>>(id, jmaterial);
 
     REQUIRE(material->id() == 0);
+
+    // Assign particle mass and volume
+    particle->assign_volume(1.0);
+    particle->assign_material(mohr_coulomb, 0);
+    particle->compute_mass();
 
     // Initialise stress
     mpm::Material<Dim>::Vector6d stress;
@@ -298,6 +307,9 @@ TEST_CASE("MohrCoulomb is checked in 2D (cohesion only, without softening)",
       // Initialise elastic state
       material->initialise(&state_variables);
 
+      std::cout << "PARTICLE_MASS_DENSITY: " << particle->mass_density()
+                << std::endl;
+
       // Check compute stress
       mpm::Material<Dim>::Vector6d updated_stress =
           mohr_coulomb->compute_stress(stress, dstrain, particle.get(),
@@ -448,6 +460,11 @@ TEST_CASE("MohrCoulomb is checked in 2D (cohesion only, without softening)",
     auto mohr_coulomb = std::make_shared<mpm::MohrCoulomb<Dim>>(id, jmaterial);
 
     REQUIRE(material->id() == 0);
+
+    // Assign particle mass and volume
+    particle->assign_volume(1.0);
+    particle->assign_material(mohr_coulomb, 0);
+    particle->compute_mass();
 
     // Initialise stress
     mpm::Material<Dim>::Vector6d stress;
@@ -670,6 +687,7 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi, without softening)",
   jmaterial["peak_pdstrain"] = 0.;
   jmaterial["residual_pdstrain"] = 0.;
   jmaterial["tension_cutoff"] = 0.;
+  jmaterial["packing_fraction"] = 0.6;
 
   //! Check yield correction based on trial stress
   SECTION("MohrCoulomb check yield correction based on trial stress") {
@@ -681,6 +699,11 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi, without softening)",
     auto mohr_coulomb = std::make_shared<mpm::MohrCoulomb<Dim>>(id, jmaterial);
 
     REQUIRE(material->id() == 0);
+
+    // Assign particle mass and volume
+    particle->assign_volume(1.0);
+    particle->assign_material(mohr_coulomb, 0);
+    particle->compute_mass();
 
     // Initialise stress
     mpm::Material<Dim>::Vector6d stress;
@@ -988,6 +1011,11 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi, without softening)",
 
     REQUIRE(material->id() == 0);
 
+    // Assign particle mass and volume
+    particle->assign_volume(1.0);
+    particle->assign_material(mohr_coulomb, 0);
+    particle->compute_mass();
+
     // Initialise stress
     mpm::Material<Dim>::Vector6d stress;
     stress.setZero();
@@ -1211,6 +1239,7 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi & psi, without softening)",
   jmaterial["peak_pdstrain"] = 0.;
   jmaterial["residual_pdstrain"] = 0.;
   jmaterial["tension_cutoff"] = 0.;
+  jmaterial["packing_fraction"] = 0.6;
 
   //! Check yield correction based on trial stress
   SECTION("MohrCoulomb check yield correction based on trial stress") {
@@ -1222,6 +1251,11 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi & psi, without softening)",
     auto mohr_coulomb = std::make_shared<mpm::MohrCoulomb<Dim>>(id, jmaterial);
 
     REQUIRE(material->id() == 0);
+
+    // Assign particle mass and volume
+    particle->assign_volume(1.0);
+    particle->assign_material(mohr_coulomb, 0);
+    particle->compute_mass();
 
     // Initialise stress
     mpm::Material<Dim>::Vector6d stress;
@@ -1291,7 +1325,7 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi & psi, without softening)",
     // Compute plastic correction components
     mohr_coulomb->compute_df_dp(yield_type, &state_variables, stress,
                                 &df_dsigma, &dp_dsigma, &dp_dq, &softening);
-    ;
+
     // Check plastic correction component based on stress
     // Check dF/dSigma
     REQUIRE(df_dsigma(0) == Approx(0.62666187).epsilon(Tolerance));
@@ -1526,6 +1560,11 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi & psi, without softening)",
 
     REQUIRE(material->id() == 0);
 
+    // Assign particle mass and volume
+    particle->assign_volume(1.0);
+    particle->assign_material(mohr_coulomb, 0);
+    particle->compute_mass();
+
     // Initialise stress
     mpm::Material<Dim>::Vector6d stress;
     stress.setZero();
@@ -1748,6 +1787,7 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi & psi, with softening)",
   jmaterial["peak_pdstrain"] = 0.;
   jmaterial["residual_pdstrain"] = 0.001;
   jmaterial["tension_cutoff"] = 0.;
+  jmaterial["packing_fraction"] = 0.6;
 
   //! Check yield correction based on trial stress
   SECTION("MohrCoulomb check yield correction based on trial stress") {
@@ -1759,6 +1799,11 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi & psi, with softening)",
     auto mohr_coulomb = std::make_shared<mpm::MohrCoulomb<Dim>>(id, jmaterial);
 
     REQUIRE(material->id() == 0);
+
+    // Assign particle mass and volume
+    particle->assign_volume(1.0);
+    particle->assign_material(mohr_coulomb, 0);
+    particle->compute_mass();
 
     // Calculate modulus values
     const double K =
@@ -2309,6 +2354,11 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi & psi, with softening)",
     auto mohr_coulomb = std::make_shared<mpm::MohrCoulomb<Dim>>(id, jmaterial);
 
     REQUIRE(material->id() == 0);
+
+    // Assign particle mass and volume
+    particle->assign_volume(1.0);
+    particle->assign_material(mohr_coulomb, 0);
+    particle->compute_mass();
 
     // Calculate modulus values
     const double K =
@@ -2884,6 +2934,7 @@ TEST_CASE("MohrCoulomb is checked in 3D (c & phi & psi, with softening)",
   jmaterial["peak_pdstrain"] = 1.E-16;
   jmaterial["residual_pdstrain"] = 0.001;
   jmaterial["tension_cutoff"] = 0.;
+  jmaterial["packing_fraction"] = 0.6;
 
   //! Check yield correction based on trial stress
   SECTION("MohrCoulomb check yield correction based on trial stress") {
@@ -2895,6 +2946,11 @@ TEST_CASE("MohrCoulomb is checked in 3D (c & phi & psi, with softening)",
     auto mohr_coulomb = std::make_shared<mpm::MohrCoulomb<Dim>>(id, jmaterial);
 
     REQUIRE(material->id() == 0);
+
+    // Assign particle mass and volume
+    particle->assign_volume(1.0);
+    particle->assign_material(mohr_coulomb, 0);
+    particle->compute_mass();
 
     // Calculate modulus values
     const double K =
@@ -3473,6 +3529,11 @@ TEST_CASE("MohrCoulomb is checked in 3D (c & phi & psi, with softening)",
     auto mohr_coulomb = std::make_shared<mpm::MohrCoulomb<Dim>>(id, jmaterial);
 
     REQUIRE(material->id() == 0);
+
+    // Assign particle mass and volume
+    particle->assign_volume(1.0);
+    particle->assign_material(mohr_coulomb, 0);
+    particle->compute_mass();
 
     // Calculate modulus values
     const double K =


### PR DESCRIPTION
**Describe the PR**
This PR adds a separate yield criterion to fix issues with volume expansion occurring in the current Mohr-Coulomb model.
To use this feature, users need to add the following two material parameters:
1. "packing_fraction" or "porosity" which determines the granular assembly's initial packing fraction or void fraction (or porosity). "porosity" (input for two-phase MPM) will be used if "packing_fraction" is not found.
2. "packing_fraction_minimum", which determines the minimum packing fraction when the material can carry stress. Below this value, the material should not carry any stress. Default "packing_fraction_minimum" is 0.0, which reverts to standard Mohr-Coulomb. 

**Related Issues/PRs**
This PR also fixes the clang-formating issue in bingham.tcc related to #99.

**Additional context**
N/A
