### PR TITLE
[Clean-up] MP IDs outside mesh domain listed with error

### DIFF
--- a/include/solvers/mpm_base.h
+++ b/include/solvers/mpm_base.h
@@ -2,6 +2,7 @@
 #define MPM_MPM_BASE_H_
 
 #include <numeric>
+#include <sstream>
 
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid.hpp>

--- a/include/solvers/mpm_explicit_twophase.tcc
+++ b/include/solvers/mpm_explicit_twophase.tcc
@@ -370,8 +370,14 @@ bool mpm::MPMExplicitTwoPhase<Tdim>::solve() {
     // Locate particles
     auto unlocatable_particles = mesh_->locate_particles_mesh();
 
-    if (!unlocatable_particles.empty() && this->locate_particles_)
-      throw std::runtime_error("Particle outside the mesh domain");
+    // Throw error with listed unlocatable particles
+    if (!unlocatable_particles.empty() && this->locate_particles_) {
+      std::ostringstream unloc_mp;
+      for (const auto& particle : unlocatable_particles)
+        unloc_mp << particle->id() << " ";
+      throw std::runtime_error("Particle(s) outside the mesh domain: " +
+                               unloc_mp.str());
+    }
     // If unable to locate particles remove particles
     if (!unlocatable_particles.empty() && !this->locate_particles_)
       for (const auto& remove_particle : unlocatable_particles)

--- a/include/solvers/mpm_scheme/mpm_scheme.h
+++ b/include/solvers/mpm_scheme/mpm_scheme.h
@@ -1,6 +1,8 @@
 #ifndef MPM_MPM_SCHEME_H_
 #define MPM_MPM_SCHEME_H_
 
+#include <sstream>
+
 #ifdef USE_GRAPH_PARTITIONING
 #include "graph.h"
 #endif

--- a/include/solvers/mpm_scheme/mpm_scheme.tcc
+++ b/include/solvers/mpm_scheme/mpm_scheme.tcc
@@ -237,8 +237,14 @@ inline void mpm::MPMScheme<Tdim>::locate_particles(bool locate_particles) {
 
   auto unlocatable_particles = mesh_->locate_particles_mesh();
 
-  if (!unlocatable_particles.empty() && locate_particles)
-    throw std::runtime_error("Particle outside the mesh domain");
+  // Throw error with listed unlocatable particles
+  if (!unlocatable_particles.empty() && locate_particles) {
+    std::ostringstream unloc_mp;
+    for (const auto& particle : unlocatable_particles)
+      unloc_mp << particle->id() << " ";
+    throw std::runtime_error("Particle(s) outside the mesh domain: " +
+                             unloc_mp.str());
+  }
   // If unable to locate particles remove particles
   if (!unlocatable_particles.empty() && !locate_particles)
     for (const auto& remove_particle : unlocatable_particles)

--- a/include/solvers/mpm_semi_implicit_navierstokes.tcc
+++ b/include/solvers/mpm_semi_implicit_navierstokes.tcc
@@ -313,8 +313,14 @@ bool mpm::MPMSemiImplicitNavierStokes<Tdim>::solve() {
     // Locate particle
     auto unlocatable_particles = mesh_->locate_particles_mesh();
 
-    if (!unlocatable_particles.empty() && this->locate_particles_)
-      throw std::runtime_error("Particle outside the mesh domain");
+    // Throw error with listed unlocatable particles
+    if (!unlocatable_particles.empty() && this->locate_particles_) {
+      std::ostringstream unloc_mp;
+      for (const auto& particle : unlocatable_particles)
+        unloc_mp << particle->id() << " ";
+      throw std::runtime_error("Particle(s) outside the mesh domain: " +
+                               unloc_mp.str());
+    }
     // If unable to locate particles remove particles
     if (!unlocatable_particles.empty() && !this->locate_particles_)
       for (const auto& remove_particle : unlocatable_particles)

--- a/include/solvers/mpm_semi_implicit_twophase.tcc
+++ b/include/solvers/mpm_semi_implicit_twophase.tcc
@@ -421,9 +421,14 @@ bool mpm::MPMSemiImplicitTwoPhase<Tdim>::solve() {
     // Locate particle
     auto unlocatable_particles = mesh_->locate_particles_mesh();
 
-    if (!unlocatable_particles.empty() && this->locate_particles_)
-      throw std::runtime_error("Particle outside the mesh domain");
-
+    // Throw error with listed unlocatable particles
+    if (!unlocatable_particles.empty() && this->locate_particles_) {
+      std::ostringstream unloc_mp;
+      for (const auto& particle : unlocatable_particles)
+        unloc_mp << particle->id() << " ";
+      throw std::runtime_error("Particle(s) outside the mesh domain: " +
+                               unloc_mp.str());
+    }
     // If unable to locate particles remove particles
     if (!unlocatable_particles.empty() && !this->locate_particles_)
       for (const auto& remove_particle : unlocatable_particles)


### PR DESCRIPTION
**Description**

Error changes for particles outside mesh domain:
- Particles leaving mesh domain will now have their IDs listed (' ' delimiter) in the error message.
- Extra string stream only created when `"locate_particles": true` in mpm.json input file.
- Requires `#include <sstream>` in `mpm_scheme.h` and `mpm_base.h`.
- This does NOT apply to errors called upon initialization (i.e., due to pre-processing) or resume. This is left without IDs listed because incorrect pre-processing could result in a list of millions of particle IDs.

Example of new console output:

![Example_ParticlesOutsideMeshDomain](https://github.com/user-attachments/assets/a0c52c3b-536f-4a46-a180-5f99cea03e85)