### PR TITLE
[Compile] Fix build with boost 1.89

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,10 @@ option(USE_PETSC "Use PETSC solver library" OFF)
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
 # Boost Archive
-find_package(Boost REQUIRED COMPONENTS filesystem system)
+find_package(Boost REQUIRED COMPONENTS filesystem)
+if(Boost_MAJOR_VERSION EQUAL 1 AND Boost_MINOR_VERSION LESS 69)
+  find_package(Boost REQUIRED COMPONENTS filesystem system)
+endif()
 include_directories(${BOOST_INCLUDE_DIRS})
 link_libraries(${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
 


### PR DESCRIPTION
**Describe the PR**
In the Boost 1.89.0 release, Boost.System stub has been removed (https://github.com/boostorg/system/commit/7a495bb46d7ccd808e4be2a6589260839b0fd3a3) which causes CMake error:
<img width="659" height="231" alt="image" src="https://github.com/user-attachments/assets/a42ec690-cf96-491a-b052-ba921031aa63" />
The Boost.System library has been header-only since 1.69 [[1]](https://github.com/standardese/standardese/pull/249#user-content-fn-1-4868579452c5329c0cbd02994a16e6bb).

**Related Issues/PRs**
https://github.com/Homebrew/homebrew-core/pull/233031

**Additional context**
Discovered this during my recent homebrew upgrades.
