### PR TITLE
[Mohr-Coulomb] Add corner return for simultaneous tension-shear yielding

### DIFF
--- a/include/materials/infinitesimal_strain/mohr_coulomb.h
+++ b/include/materials/infinitesimal_strain/mohr_coulomb.h
@@ -124,6 +124,19 @@ class MohrCoulomb : public InfinitesimalElastoPlastic<Tdim> {
   inline double check_low(double val) {
     return (val > 1.0e-15 ? val : 1.0e-15);
   }
+  void update_softening_parameters(mpm::dense_map* state_vars);
+  std::tuple<Vector6d, double, bool> compute_single_surface_return(
+      mpm::mohrcoulomb::FailureState yield_type,
+      const Eigen::Matrix<double, 2, 1>& yield_function,
+      const Vector6d& current_stress,
+      const Matrix6x6& de,
+      mpm::dense_map* state_vars);
+
+  //! Compute corner return mapping for multi-surface failure
+  std::tuple<Vector6d, double, bool> compute_corner_return(
+      const Vector6d& current_stress,
+      const Matrix6x6& de,
+      mpm::dense_map* state_vars);
 
   //! Density
   double density_{std::numeric_limits<double>::max()};

--- a/include/materials/infinitesimal_strain/mohr_coulomb.h
+++ b/include/materials/infinitesimal_strain/mohr_coulomb.h
@@ -128,14 +128,12 @@ class MohrCoulomb : public InfinitesimalElastoPlastic<Tdim> {
   std::tuple<Vector6d, double, bool> compute_single_surface_return(
       mpm::mohrcoulomb::FailureState yield_type,
       const Eigen::Matrix<double, 2, 1>& yield_function,
-      const Vector6d& current_stress,
-      const Matrix6x6& de,
+      const Vector6d& current_stress, const Matrix6x6& de,
       mpm::dense_map* state_vars);
 
   //! Compute corner return mapping for multi-surface failure
   std::tuple<Vector6d, double, bool> compute_corner_return(
-      const Vector6d& current_stress,
-      const Matrix6x6& de,
+      const Vector6d& current_stress, const Matrix6x6& de,
       mpm::dense_map* state_vars);
 
   //! Density

--- a/include/materials/infinitesimal_strain/mohr_coulomb.h
+++ b/include/materials/infinitesimal_strain/mohr_coulomb.h
@@ -13,7 +13,13 @@ namespace mpm {
 
 namespace mohrcoulomb {
 //! Failure state
-enum FailureState { Elastic = 0, Shear = 1, Tensile = 2, Separated = 3 };
+enum FailureState {
+  Elastic = 0,
+  Shear = 1,
+  Tensile = 2,
+  ShearTensile = 3,
+  Separated = 4
+};
 }  // namespace mohrcoulomb
 
 //! MohrCoulomb class
@@ -132,9 +138,12 @@ class MohrCoulomb : public InfinitesimalElastoPlastic<Tdim> {
       mpm::dense_map* state_vars);
 
   //! Compute corner return mapping for multi-surface failure
-  std::tuple<Vector6d, double, bool> compute_corner_return(
+  std::tuple<Vector6d, Vector6d, Vector6d> compute_corner_return(
       const Vector6d& current_stress, const Matrix6x6& de,
-      mpm::dense_map* state_vars);
+      mpm::dense_map* state_vars,
+      const Eigen::Matrix<double, 2, 1>& yield_function,
+      Eigen::Matrix<double, 2, 1>& unknowns,
+      Eigen::Matrix<double, 2, 1>& dlambda);
 
   //! Density
   double density_{std::numeric_limits<double>::max()};
@@ -176,7 +185,19 @@ class MohrCoulomb : public InfinitesimalElastoPlastic<Tdim> {
       {0, mpm::mohrcoulomb::FailureState::Elastic},
       {1, mpm::mohrcoulomb::FailureState::Shear},
       {2, mpm::mohrcoulomb::FailureState::Tensile},
-      {3, mpm::mohrcoulomb::FailureState::Separated}};
+      {3, mpm::mohrcoulomb::FailureState::ShearTensile},
+      {4, mpm::mohrcoulomb::FailureState::Separated}};
+
+  // Parameters for return mapping algorithm
+  //! Absolute tolerance
+  double abs_tol_{1.e-10};
+  //! Relative tolerance
+  double rel_tol_{1.e-8};
+  //! Maximum number of iterations
+  unsigned max_iter_{15};
+
+  //! Discrete tolerance
+  double tolerance_{1.0e-7};
 };  // MohrCoulomb class
 }  // namespace mpm
 

--- a/include/materials/infinitesimal_strain/mohr_coulomb.tcc
+++ b/include/materials/infinitesimal_strain/mohr_coulomb.tcc
@@ -197,7 +197,7 @@ void mpm::MohrCoulomb<Tdim>::compute_df_dp(
     const Vector6d& stress, Vector6d* df_dsigma, Vector6d* dp_dsigma,
     double* dp_dq, double* softening) {
   // Get stress invariants
-  const double rho = std::sqrt(2.0) * state_vars.at("tau");
+  const double rho = std::sqrt(2.0) * (*state_vars).at("tau");
   const double theta = (*state_vars).at("theta");
   // Get MC parameters
   const double phi = (*state_vars).at("phi");

--- a/include/materials/infinitesimal_strain/mohr_coulomb.tcc
+++ b/include/materials/infinitesimal_strain/mohr_coulomb.tcc
@@ -140,7 +140,7 @@ typename mpm::mohrcoulomb::FailureState
         Eigen::Matrix<double, 2, 1>* yield_function,
         const mpm::dense_map& state_vars) {
   // Tolerance for yield function
-  const double Tolerance = -1E-1;
+  const double Tolerance = 1E-7;
   // Get stress invariants
   const double epsilon = state_vars.at("epsilon");
   const double rho = state_vars.at("rho");
@@ -342,48 +342,23 @@ void mpm::MohrCoulomb<Tdim>::compute_df_dp(
         (-1.) * ((df_dphi * dphi_dpstrain) + (df_dc * dc_dpstrain)) * (*dp_dq);
   }
 }
-
-//! Compute stress
 template <unsigned Tdim>
 Eigen::Matrix<double, 6, 1> mpm::MohrCoulomb<Tdim>::compute_stress(
     const Vector6d& stress, const Vector6d& dstrain,
     const ParticleBase<Tdim>* ptr, mpm::dense_map* state_vars, double dt) {
 
-  // Density and packing parameters
+  // =========================================================================
+  // 1. Constants and initialization
+  // =========================================================================
+  const double Tolerance = 1E-7;         // Yield-function tolerance
+  const unsigned itr_max = 50;           // Maximum return-mapping iterations
+  const double G = shear_modulus_;
+  
+  // Check density criterion for tensile separation.
   const double current_packing_density = ptr->mass_density();
   const double critical_density = minimum_packing_fraction_ * grain_density_;
 
-  // Get previous time step state variable
-  const auto prev_state_vars = (*state_vars);
-  const double pdstrain = (*state_vars).at("pdstrain");
-  // Update MC parameters using a linear softening rule
-  if (softening_ && pdstrain > pdstrain_peak_) {
-    if (pdstrain < pdstrain_residual_) {
-      (*state_vars).at("phi") =
-          phi_residual_ +
-          ((phi_peak_ - phi_residual_) * (pdstrain - pdstrain_residual_) /
-           (pdstrain_peak_ - pdstrain_residual_));
-      (*state_vars).at("psi") =
-          psi_residual_ +
-          ((psi_peak_ - psi_residual_) * (pdstrain - pdstrain_residual_) /
-           (pdstrain_peak_ - pdstrain_residual_));
-      (*state_vars).at("cohesion") =
-          cohesion_residual_ + ((cohesion_peak_ - cohesion_residual_) *
-                                (pdstrain - pdstrain_residual_) /
-                                (pdstrain_peak_ - pdstrain_residual_));
-    } else {
-      (*state_vars).at("phi") = phi_residual_;
-      (*state_vars).at("psi") = psi_residual_;
-      (*state_vars).at("cohesion") = cohesion_residual_;
-    }
-    // Modify tension cutoff acoording to softening law
-    const double apex =
-        (*state_vars).at("cohesion") / std::tan((*state_vars).at("phi"));
-    if ((*state_vars).at("tension_cutoff") > apex)
-      (*state_vars).at("tension_cutoff") = check_low(apex);
-  }
-  //-------------------------------------------------------------------------
-  // Elastic-predictor stage: compute the trial stress
+  // Compute elastic stiffness.
   (*state_vars).at("yield_state") = 0;
   Matrix6x6 de = this->compute_elastic_tensor(state_vars);
   Vector6d trial_stress =
@@ -397,119 +372,395 @@ Eigen::Matrix<double, 6, 1> mpm::MohrCoulomb<Tdim>::compute_stress(
   }
   // Compute stress invariants based on trial stress
   this->compute_stress_invariants(trial_stress, state_vars);
-  // Compute yield function based on the trial stress
-  Eigen::Matrix<double, 2, 1> yield_function_trial;
-  auto yield_type_trial =
-      this->compute_yield_state(&yield_function_trial, (*state_vars));
-  // Return the updated stress in elastic state
-  if (yield_type_trial == mpm::mohrcoulomb::FailureState::Elastic) {
+
+  // Evaluate yield functions at trial stress.
+  Eigen::Matrix<double, 2, 1> yield_function;
+  auto yield_type = this->compute_yield_state(&yield_function, (*state_vars));
+
+  // Elastic admissibility: if both surfaces are satisfied, accept trial stress.
+  if (yield_function(0) <= Tolerance && yield_function(1) <= Tolerance) {
     (*state_vars).at("yield_state") = 0;
     return trial_stress;
   }
-  //-------------------------------------------------------------------------
-  // Plastic-corrector stage: correct the stress back to the yield surface
-  // Define tolerance of yield function
-  const double Tolerance = 1E-1;
-  // Compute plastic multiplier based on trial stress (Lambda trial)
-  double softening_trial = 0.;
-  double dp_dq_trial = 0.;
-  Vector6d df_dsigma_trial = Vector6d::Zero();
-  Vector6d dp_dsigma_trial = Vector6d::Zero();
-  this->compute_df_dp(yield_type_trial, state_vars, trial_stress,
-                      &df_dsigma_trial, &dp_dsigma_trial, &dp_dq_trial,
-                      &softening_trial);
-  double yield_trial = 0.;
-  if (yield_type_trial == mpm::mohrcoulomb::FailureState::Tensile) {
-    (*state_vars).at("yield_state") = 2;
-    yield_trial = yield_function_trial(0);
-  }
-  if (yield_type_trial == mpm::mohrcoulomb::FailureState::Shear) {
-    (*state_vars).at("yield_state") = 1;
-    yield_trial = yield_function_trial(1);
-  }
-  de = this->compute_elastic_tensor(state_vars);
-  double lambda_trial =
-      yield_trial /
-      ((df_dsigma_trial.transpose() * de).dot(dp_dsigma_trial.transpose()) +
-       softening_trial);
-  // Compute stress invariants based on stress input
-  this->compute_stress_invariants(stress, state_vars);
-  // Compute yield function based on stress input
-  Eigen::Matrix<double, 2, 1> yield_function;
-  auto yield_type = this->compute_yield_state(&yield_function, (*state_vars));
-  // Initialise value of yield function based on stress
-  double yield{std::numeric_limits<double>::max()};
-  if (yield_type == mpm::mohrcoulomb::FailureState::Tensile)
-    yield = yield_function(0);
-  if (yield_type == mpm::mohrcoulomb::FailureState::Shear)
-    yield = yield_function(1);
-  // Compute plastic multiplier based on stress input (Lambda)
-  double softening = 0.;
-  double dp_dq = 0.;
-  Vector6d df_dsigma = Vector6d::Zero();
-  Vector6d dp_dsigma = Vector6d::Zero();
-  this->compute_df_dp(yield_type, state_vars, stress, &df_dsigma, &dp_dsigma,
-                      &dp_dq, &softening);
-  const double lambda =
-      ((df_dsigma.transpose() * de).dot(dstrain)) /
-      (((df_dsigma.transpose() * de).dot(dp_dsigma)) + softening);
-  // Initialise updated stress
-  Vector6d updated_stress = trial_stress;
-  // Initialise incremental of plastic deviatoric strain
-  double dpdstrain = 0.;
-  // Correction stress based on stress
-  if (fabs(yield) < Tolerance) {
-    // Compute updated stress
-    updated_stress += -(lambda * de * dp_dsigma);
-    // Compute incremental of plastic deviatoric strain
-    dpdstrain = lambda * dp_dq;
-  } else {
-    // Compute updated stress
-    updated_stress += -(lambda_trial * de * dp_dsigma_trial);
-    // Compute incremental of plastic deviatoric strain
-    dpdstrain = lambda_trial * dp_dq_trial;
-  }
 
-  // Define the maximum iteration step
-  const int itr_max = 100;
-  // Correct the stress again
+  // =========================================================================
+  // 3. Plastic corrector (cutting-plane + corner return)
+  //
+  // The stress is projected back to the admissible domain by incremental
+  // return mapping. A single violated surface uses one plastic multiplier;
+  // simultaneous tension/shear violation uses a multi-surface corner return.
+  // =========================================================================
+  
+  Vector6d current_stress = trial_stress;
+  bool converged = false;
+
   for (unsigned itr = 0; itr < itr_max; ++itr) {
-    // Check the update stress
-    // Compute stress invariants based on updated stress
-    this->compute_stress_invariants(updated_stress, state_vars);
-    // Compute yield function based on updated stress
-    yield_type_trial =
-        this->compute_yield_state(&yield_function_trial, (*state_vars));
-    // Check yield function
-    if (yield_function_trial(0) < Tolerance &&
-        yield_function_trial(1) < Tolerance) {
+    // ---------------------------------------------------------------------
+    // A. Re-evaluate invariants and active surface at current stress.
+    // ---------------------------------------------------------------------
+    this->compute_stress_invariants(current_stress, state_vars);
+    yield_type = this->compute_yield_state(&yield_function, (*state_vars));
+
+    // ---------------------------------------------------------------------
+    // B. Convergence check
+    // ---------------------------------------------------------------------
+    if (yield_function(0) <= Tolerance && yield_function(1) <= Tolerance) {
+      converged = true;
+      // Assign final yield state near the converged point.
+      if (yield_function(0) > -Tolerance && yield_function(1) <= -Tolerance) {
+        (*state_vars).at("yield_state") = 2;  // Tensile
+      } else if (yield_function(1) > -Tolerance && yield_function(0) <= -Tolerance) {
+        (*state_vars).at("yield_state") = 1;  // Shear
+      } else {
+        (*state_vars).at("yield_state") = 0;  // Elastic
+      }
       break;
     }
-    // Compute plastic multiplier based on updated stress
-    this->compute_df_dp(yield_type_trial, state_vars, updated_stress,
-                        &df_dsigma_trial, &dp_dsigma_trial, &dp_dq_trial,
-                        &softening_trial);
-    if (yield_type_trial == mpm::mohrcoulomb::FailureState::Tensile)
-      yield_trial = yield_function_trial(0);
-    if (yield_type_trial == mpm::mohrcoulomb::FailureState::Shear)
-      yield_trial = yield_function_trial(1);
-    // Compute plastic multiplier based on updated stress
-    lambda_trial =
-        yield_trial /
-        ((df_dsigma_trial.transpose() * de).dot(dp_dsigma_trial.transpose()) +
-         softening_trial);
-    // Correct stress back to the yield surface
-    updated_stress += -(lambda_trial * de * dp_dsigma_trial);
-    // Update incremental of plastic deviatoric strain
-    dpdstrain += lambda_trial * dp_dq_trial;
+
+    // ---------------------------------------------------------------------
+    // C. Determine active mechanism and choose return strategy.
+    // ---------------------------------------------------------------------
+    const bool tension_violated = (yield_function(0) > Tolerance);
+    const bool shear_violated = (yield_function(1) > Tolerance);
+
+    Vector6d stress_correction = Vector6d::Zero();
+    double dpdstrain_inc = 0.0;
+
+    if (tension_violated && shear_violated) {
+      // =================================================================
+      // Corner return mapping (multi-surface plasticity)
+      // Used when both tension and shear surfaces are violated.
+      // =================================================================
+      auto [corner_correction, corner_dpdstrain, corner_success] = 
+          this->compute_corner_return(current_stress, de, state_vars);
+      
+      if (corner_success) {
+        stress_correction = corner_correction;
+        dpdstrain_inc = corner_dpdstrain;
+      } else {
+        // If corner return fails, fall back to single-surface return on the
+        // most violated surface.
+        if (yield_function(0) > yield_function(1)) {
+          yield_type = mpm::mohrcoulomb::FailureState::Tensile;
+        } else {
+          yield_type = mpm::mohrcoulomb::FailureState::Shear;
+        }
+        const auto single_return = this->compute_single_surface_return(
+            yield_type, yield_function, current_stress, de, state_vars);
+        stress_correction = std::get<0>(single_return);
+        dpdstrain_inc = std::get<1>(single_return);
+      }
+    } else {
+      // =================================================================
+      // Single-surface return mapping
+      // =================================================================
+      if (tension_violated) {
+        yield_type = mpm::mohrcoulomb::FailureState::Tensile;
+        (*state_vars).at("yield_state") = 2;
+      } else {
+        yield_type = mpm::mohrcoulomb::FailureState::Shear;
+        (*state_vars).at("yield_state") = 1;
+      }
+      
+      const auto single_return = this->compute_single_surface_return(
+          yield_type, yield_function, current_stress, de, state_vars);
+      stress_correction = std::get<0>(single_return);
+      dpdstrain_inc = std::get<1>(single_return);
+    }
+
+    // ---------------------------------------------------------------------
+    // D. Update stress and internal variable.
+    // ---------------------------------------------------------------------
+    current_stress += stress_correction;
+    (*state_vars).at("pdstrain") += dpdstrain_inc;
+
+    // Update softening-dependent strength parameters.
+    if (softening_) {
+      this->update_softening_parameters(state_vars);
+    }
   }
-  // Compute stress invariants based on updated stress
-  this->compute_stress_invariants(updated_stress, state_vars);
 
-  // Update plastic deviatoric strain
-  (*state_vars).at("pdstrain") += dpdstrain;
+  // =========================================================================
+  // 4. Post-convergence handling
+  // =========================================================================
+  if (!converged) {
+    // Warn when return mapping fails to converge within the iteration budget.
+    console_->warn(
+        "MohrCoulomb::compute_stress: Return mapping did not converge "
+        "after {} iterations. Final yield functions: f_t = {}, f_s = {}",
+        itr_max, yield_function(0), yield_function(1));
+  }
 
-  return updated_stress;
+  // Store final stress invariants.
+  this->compute_stress_invariants(current_stress, state_vars);
+
+  return current_stress;
+}
+//! Single-surface return mapping
+//! Returns: (stress correction, plastic deviatoric strain increment, success flag)
+template <unsigned Tdim>
+std::tuple<Eigen::Matrix<double, 6, 1>, double, bool>
+mpm::MohrCoulomb<Tdim>::compute_single_surface_return(
+    mpm::mohrcoulomb::FailureState yield_type,
+    const Eigen::Matrix<double, 2, 1>& yield_function,
+    const Vector6d& current_stress,
+    const Matrix6x6& de,
+    mpm::dense_map* state_vars) {
+  
+  const double Min_Denominator = 1E-15;
+  
+  // Select active yield-function value on the current surface.
+  double f_current = (yield_type == mpm::mohrcoulomb::FailureState::Tensile) 
+                     ? yield_function(0) : yield_function(1);
+  
+  // Compute flow/yield gradients and softening contribution.
+  Vector6d df_dsigma = Vector6d::Zero();
+  Vector6d dp_dsigma = Vector6d::Zero();
+  double dp_dq = 0.0;
+  double softening_modulus = 0.0;
+
+  this->compute_df_dp(yield_type, state_vars, current_stress,
+                      &df_dsigma, &dp_dsigma, &dp_dq, &softening_modulus);
+
+  // Consistency denominator:
+  // n^T De m + H, where n = dF/dsigma, m = dP/dsigma, H = softening term.
+  double denominator = (df_dsigma.transpose() * de).dot(dp_dsigma) + softening_modulus;
+  
+  // =========================================================================
+  // Denominator regularization
+  // =========================================================================
+  bool success = true;
+  if (denominator < Min_Denominator) {
+    if (denominator < -Min_Denominator) {
+      // Negative denominator indicates local instability due to strong softening.
+      console_->warn(
+          "MohrCoulomb: Negative denominator detected ({:.6e}). "
+          "This indicates material instability (strong softening). "
+          "Using regularization.",
+          denominator);
+      // Regularize to a small positive value.
+      denominator = Min_Denominator;
+      success = false;  // Mark partially successful correction.
+    } else {
+      // Near-zero denominator implies numerical singularity.
+      console_->debug(
+          "MohrCoulomb: Near-zero denominator detected ({:.6e}). "
+          "Applying regularization.",
+          denominator);
+      denominator = Min_Denominator;
+    }
+  }
+
+  // Plastic multiplier increment from first-order consistency.
+  double dlambda = f_current / denominator;
+  
+  // Physical admissibility check.
+  if (dlambda < 0.0) {
+    // Negative plastic multiplier is non-admissible for this active set.
+    console_->warn(
+        "MohrCoulomb: Negative plastic multiplier ({:.6e}). Setting to zero.",
+        dlambda);
+    dlambda = 0.0;
+    success = false;
+  }
+  
+  // Clamp very large multiplier increments for numerical robustness.
+  const double max_dlambda = 1.0;  // Can be tuned per problem class.
+  if (dlambda > max_dlambda) {
+    console_->debug(
+        "MohrCoulomb: Large plastic multiplier ({:.6e}). Clamping to {:.6e}.",
+        dlambda, max_dlambda);
+    dlambda = max_dlambda;
+  }
+
+  // Stress update: Delta sigma = -dlambda * De * dP/dsigma.
+  Vector6d stress_correction = -dlambda * de * dp_dsigma;
+  // Internal variable increment from equivalent plastic deviatoric measure.
+  double dpdstrain = dlambda * dp_dq;
+
+  return {stress_correction, dpdstrain, success};
+}
+
+//! Corner return mapping (multi-surface)
+//! Applies Koiter's rule when both tension and shear surfaces are active.
+//! Returns: (stress correction, plastic deviatoric strain increment, success flag)
+template <unsigned Tdim>
+std::tuple<Eigen::Matrix<double, 6, 1>, double, bool>
+mpm::MohrCoulomb<Tdim>::compute_corner_return(
+    const Vector6d& current_stress,
+    const Matrix6x6& de,
+    mpm::dense_map* state_vars) {
+  
+  const double Min_Denominator = 1E-15;
+  
+  // Compute gradients for both active surfaces.
+  Vector6d df_dsigma_t = Vector6d::Zero();  // Tension
+  Vector6d dp_dsigma_t = Vector6d::Zero();
+  double dp_dq_t = 0.0;
+  double softening_t = 0.0;
+  
+  Vector6d df_dsigma_s = Vector6d::Zero();  // Shear
+  Vector6d dp_dsigma_s = Vector6d::Zero();
+  double dp_dq_s = 0.0;
+  double softening_s = 0.0;
+
+  this->compute_df_dp(mpm::mohrcoulomb::FailureState::Tensile, state_vars, 
+                      current_stress, &df_dsigma_t, &dp_dsigma_t, &dp_dq_t, &softening_t);
+  this->compute_df_dp(mpm::mohrcoulomb::FailureState::Shear, state_vars,
+                      current_stress, &df_dsigma_s, &dp_dsigma_s, &dp_dq_s, &softening_s);
+
+  // Recompute yield-function values at the current stress.
+  Eigen::Matrix<double, 2, 1> yield_function;
+  this->compute_yield_state(&yield_function, (*state_vars));
+  const double f_t = yield_function(0);  // Tension
+  const double f_s = yield_function(1);  // Shear
+
+  // =========================================================================
+  // Solve 2x2 consistency system for the two plastic multipliers:
+  // [A11 A12] [lambda_t]   [f_t]
+  // [A21 A22] [lambda_s] = [f_s]
+  // with A_ij = n_i^T De m_j + H_i delta_ij.
+  // =========================================================================
+  
+  Eigen::Matrix<double, 2, 2> A;
+  Eigen::Vector2d b;
+  
+  // Assemble system matrix.
+  Vector6d de_dp_t = de * dp_dsigma_t;
+  Vector6d de_dp_s = de * dp_dsigma_s;
+  
+  A(0, 0) = df_dsigma_t.dot(de_dp_t) + softening_t;
+  A(0, 1) = df_dsigma_t.dot(de_dp_s);
+  A(1, 0) = df_dsigma_s.dot(de_dp_t);
+  A(1, 1) = df_dsigma_s.dot(de_dp_s) + softening_s;
+  
+  b(0) = f_t;
+  b(1) = f_s;
+
+  // Check determinant for singular/ill-conditioned corner system.
+  double det_A = A(0, 0) * A(1, 1) - A(0, 1) * A(1, 0);
+  
+  if (std::abs(det_A) < Min_Denominator) {
+    // Singular or near-singular system: corner return is not reliable.
+    console_->debug(
+        "MohrCoulomb: Corner return matrix is singular (det = {:.6e}). "
+        "Falling back to single surface return.",
+        det_A);
+    return {Vector6d::Zero(), 0.0, false};
+  }
+
+  // Solve explicitly via inverse (closed form for 2x2).
+  Eigen::Matrix<double, 2, 2> A_inv;
+  A_inv(0, 0) =  A(1, 1) / det_A;
+  A_inv(0, 1) = -A(0, 1) / det_A;
+  A_inv(1, 0) = -A(1, 0) / det_A;
+  A_inv(1, 1) =  A(0, 0) / det_A;
+  
+  Eigen::Vector2d lambdas = A_inv * b;
+  double lambda_t = lambdas(0);
+  double lambda_s = lambdas(1);
+
+  // =========================================================================
+  // Plastic multiplier admissibility checks
+  // =========================================================================
+  bool success = true;
+  
+  // Check for negative multipliers.
+  if (lambda_t < 0.0 || lambda_s < 0.0) {
+    if (lambda_t < 0.0 && lambda_s < 0.0) {
+      // Both negative: active-set assumption is invalid.
+      console_->debug(
+          "MohrCoulomb: Both plastic multipliers negative (λ_t={:.6e}, λ_s={:.6e}). "
+          "Corner return failed.",
+          lambda_t, lambda_s);
+      return {Vector6d::Zero(), 0.0, false};
+    } else if (lambda_t < 0.0) {
+      // Negative tension multiplier: prefer single shear-surface return.
+      console_->debug(
+          "MohrCoulomb: Tension plastic multiplier negative. "
+          "Should use single shear surface return.");
+      return {Vector6d::Zero(), 0.0, false};
+    } else {
+      // Negative shear multiplier: prefer single tension-surface return.
+      console_->debug(
+          "MohrCoulomb: Shear plastic multiplier negative. "
+          "Should use single tension surface return.");
+      return {Vector6d::Zero(), 0.0, false};
+    }
+  }
+
+  // Clamp excessively large multipliers.
+  const double max_lambda = 1.0;
+  if (lambda_t > max_lambda) {
+    lambda_t = max_lambda;
+    success = false;
+  }
+  if (lambda_s > max_lambda) {
+    lambda_s = max_lambda;
+    success = false;
+  }
+
+  // =========================================================================
+  // Stress correction by Koiter's rule:
+  // Delta sigma = -De * (lambda_t * m_t + lambda_s * m_s)
+  // =========================================================================
+  Vector6d stress_correction = -de * (lambda_t * dp_dsigma_t + lambda_s * dp_dsigma_s);
+  
+  // Equivalent plastic deviatoric strain increment from both mechanisms.
+  double dpdstrain = lambda_t * dp_dq_t + lambda_s * dp_dq_s;
+
+  return {stress_correction, dpdstrain, success};
+}
+
+//! Update softening parameters
+template <unsigned Tdim>
+void mpm::MohrCoulomb<Tdim>::update_softening_parameters(mpm::dense_map* state_vars) {
+  const double pdstrain = (*state_vars).at("pdstrain");
+  
+  if (pdstrain <= pdstrain_peak_) {
+    // Pre-peak: keep peak strength parameters.
+    (*state_vars).at("phi") = phi_peak_;
+    (*state_vars).at("psi") = psi_peak_;
+    (*state_vars).at("cohesion") = cohesion_peak_;
+  } else if (pdstrain >= pdstrain_residual_) {
+    // Post-residual: keep residual strength parameters.
+    (*state_vars).at("phi") = phi_residual_;
+    (*state_vars).at("psi") = psi_residual_;
+    (*state_vars).at("cohesion") = cohesion_residual_;
+  } else {
+    // Linear softening law between peak and residual states.
+    const double ratio = (pdstrain - pdstrain_peak_) / 
+                         (pdstrain_residual_ - pdstrain_peak_);
+    (*state_vars).at("phi") = phi_peak_ + ratio * (phi_residual_ - phi_peak_);
+    (*state_vars).at("psi") = psi_peak_ + ratio * (psi_residual_ - psi_peak_);
+    (*state_vars).at("cohesion") = cohesion_peak_ + ratio * (cohesion_residual_ - cohesion_peak_);
+  }
+  
+  // Enforce apex condition: sigma_t <= c / tan(phi) for MC cone closure.
+  const double phi = (*state_vars).at("phi");
+  const double cohesion = (*state_vars).at("cohesion");
+  
+  // Guard against near-zero tan(phi).
+  const double tan_phi = std::tan(phi);
+  const double min_tan_phi = 1.0e-10;
+  
+  double apex;
+  if (std::abs(tan_phi) < min_tan_phi) {
+    // For phi ~= 0, apex tends to a very large value.
+    apex = std::numeric_limits<double>::max();
+  } else {
+    apex = cohesion / tan_phi;
+  }
+  
+  // Clamp tension cutoff by apex.
+  if ((*state_vars).at("tension_cutoff") > apex) {
+    (*state_vars).at("tension_cutoff") = apex;
+  }
+  
+  // Keep tensile cutoff non-negative.
+  if ((*state_vars).at("tension_cutoff") < 0.0) {
+    (*state_vars).at("tension_cutoff") = 0.0;
+  }
 }
 
 //! Compute elastic tensor

--- a/include/materials/infinitesimal_strain/mohr_coulomb.tcc
+++ b/include/materials/infinitesimal_strain/mohr_coulomb.tcc
@@ -99,10 +99,10 @@ mpm::dense_map mpm::MohrCoulomb<Tdim>::initialise_state_variables() {
                      ? tension_cutoff_
                      : cohesion_peak_ / std::tan(phi_peak_))},
       // Stress invariants
-      // Epsilon
-      {"epsilon", 0.},
-      // Rho
-      {"rho", 0.},
+      // Pressure
+      {"pressure", 0.},
+      // Tau
+      {"tau", 0.},
       // Theta
       {"theta", 0.},
       // Plastic deviatoric strain
@@ -115,7 +115,7 @@ template <unsigned Tdim>
 std::vector<std::string> mpm::MohrCoulomb<Tdim>::state_variables() const {
   const std::vector<std::string> state_vars = {
       "yield_state", "phi", "psi",   "cohesion", "tension_cutoff",
-      "epsilon",     "rho", "theta", "pdstrain"};
+      "pressure",    "tau", "theta", "pdstrain"};
   return state_vars;
 }
 
@@ -124,11 +124,11 @@ template <unsigned Tdim>
 bool mpm::MohrCoulomb<Tdim>::compute_stress_invariants(
     const Vector6d& stress, mpm::dense_map* state_vars) {
   // Compute the mean pressure
-  (*state_vars).at("epsilon") = mpm::materials::p(stress) * std::sqrt(3.);
+  (*state_vars).at("pressure") = -mpm::materials::p(stress);
   // Compute theta value
   (*state_vars).at("theta") = mpm::materials::lode_angle(stress);
-  // Compute rho
-  (*state_vars).at("rho") = std::sqrt(2. * mpm::materials::j2(stress));
+  // Compute tau
+  (*state_vars).at("tau") = std::sqrt(mpm::materials::j2(stress));
 
   return true;
 }
@@ -142,8 +142,8 @@ typename mpm::mohrcoulomb::FailureState
   // Tolerance for yield function
   const double Tolerance = 1E-7;
   // Get stress invariants
-  const double epsilon = state_vars.at("epsilon");
-  const double rho = state_vars.at("rho");
+  const double epsilon = -state_vars.at("pressure") * std::sqrt(3.);
+  const double rho = std::sqrt(2.0) * state_vars.at("tau");
   const double theta = state_vars.at("theta");
   // Get MC parameters
   const double phi = state_vars.at("phi");
@@ -197,7 +197,7 @@ void mpm::MohrCoulomb<Tdim>::compute_df_dp(
     const Vector6d& stress, Vector6d* df_dsigma, Vector6d* dp_dsigma,
     double* dp_dq, double* softening) {
   // Get stress invariants
-  const double rho = (*state_vars).at("rho");
+  const double rho = std::sqrt(2.0) * state_vars.at("tau");
   const double theta = (*state_vars).at("theta");
   // Get MC parameters
   const double phi = (*state_vars).at("phi");

--- a/include/materials/infinitesimal_strain/mohr_coulomb.tcc
+++ b/include/materials/infinitesimal_strain/mohr_coulomb.tcc
@@ -352,7 +352,6 @@ Eigen::Matrix<double, 6, 1> mpm::MohrCoulomb<Tdim>::compute_stress(
   // =========================================================================
   const double Tolerance = 1E-7;  // Yield-function tolerance
   const unsigned itr_max = 50;    // Maximum return-mapping iterations
-  const double G = shear_modulus_;
 
   // Check density criterion for tensile separation.
   const double current_packing_density = ptr->mass_density();

--- a/include/materials/infinitesimal_strain/mohr_coulomb.tcc
+++ b/include/materials/infinitesimal_strain/mohr_coulomb.tcc
@@ -350,10 +350,10 @@ Eigen::Matrix<double, 6, 1> mpm::MohrCoulomb<Tdim>::compute_stress(
   // =========================================================================
   // 1. Constants and initialization
   // =========================================================================
-  const double Tolerance = 1E-7;         // Yield-function tolerance
-  const unsigned itr_max = 50;           // Maximum return-mapping iterations
+  const double Tolerance = 1E-7;  // Yield-function tolerance
+  const unsigned itr_max = 50;    // Maximum return-mapping iterations
   const double G = shear_modulus_;
-  
+
   // Check density criterion for tensile separation.
   const double current_packing_density = ptr->mass_density();
   const double critical_density = minimum_packing_fraction_ * grain_density_;
@@ -390,7 +390,7 @@ Eigen::Matrix<double, 6, 1> mpm::MohrCoulomb<Tdim>::compute_stress(
   // return mapping. A single violated surface uses one plastic multiplier;
   // simultaneous tension/shear violation uses a multi-surface corner return.
   // =========================================================================
-  
+
   Vector6d current_stress = trial_stress;
   bool converged = false;
 
@@ -409,7 +409,8 @@ Eigen::Matrix<double, 6, 1> mpm::MohrCoulomb<Tdim>::compute_stress(
       // Assign final yield state near the converged point.
       if (yield_function(0) > -Tolerance && yield_function(1) <= -Tolerance) {
         (*state_vars).at("yield_state") = 2;  // Tensile
-      } else if (yield_function(1) > -Tolerance && yield_function(0) <= -Tolerance) {
+      } else if (yield_function(1) > -Tolerance &&
+                 yield_function(0) <= -Tolerance) {
         (*state_vars).at("yield_state") = 1;  // Shear
       } else {
         (*state_vars).at("yield_state") = 0;  // Elastic
@@ -431,9 +432,9 @@ Eigen::Matrix<double, 6, 1> mpm::MohrCoulomb<Tdim>::compute_stress(
       // Corner return mapping (multi-surface plasticity)
       // Used when both tension and shear surfaces are violated.
       // =================================================================
-      auto [corner_correction, corner_dpdstrain, corner_success] = 
+      auto [corner_correction, corner_dpdstrain, corner_success] =
           this->compute_corner_return(current_stress, de, state_vars);
-      
+
       if (corner_success) {
         stress_correction = corner_correction;
         dpdstrain_inc = corner_dpdstrain;
@@ -461,7 +462,7 @@ Eigen::Matrix<double, 6, 1> mpm::MohrCoulomb<Tdim>::compute_stress(
         yield_type = mpm::mohrcoulomb::FailureState::Shear;
         (*state_vars).at("yield_state") = 1;
       }
-      
+
       const auto single_return = this->compute_single_surface_return(
           yield_type, yield_function, current_stress, de, state_vars);
       stress_correction = std::get<0>(single_return);
@@ -497,42 +498,45 @@ Eigen::Matrix<double, 6, 1> mpm::MohrCoulomb<Tdim>::compute_stress(
   return current_stress;
 }
 //! Single-surface return mapping
-//! Returns: (stress correction, plastic deviatoric strain increment, success flag)
+//! Returns: (stress correction, plastic deviatoric strain increment, success
+//! flag)
 template <unsigned Tdim>
 std::tuple<Eigen::Matrix<double, 6, 1>, double, bool>
-mpm::MohrCoulomb<Tdim>::compute_single_surface_return(
-    mpm::mohrcoulomb::FailureState yield_type,
-    const Eigen::Matrix<double, 2, 1>& yield_function,
-    const Vector6d& current_stress,
-    const Matrix6x6& de,
-    mpm::dense_map* state_vars) {
-  
+    mpm::MohrCoulomb<Tdim>::compute_single_surface_return(
+        mpm::mohrcoulomb::FailureState yield_type,
+        const Eigen::Matrix<double, 2, 1>& yield_function,
+        const Vector6d& current_stress, const Matrix6x6& de,
+        mpm::dense_map* state_vars) {
+
   const double Min_Denominator = 1E-15;
-  
+
   // Select active yield-function value on the current surface.
-  double f_current = (yield_type == mpm::mohrcoulomb::FailureState::Tensile) 
-                     ? yield_function(0) : yield_function(1);
-  
+  double f_current = (yield_type == mpm::mohrcoulomb::FailureState::Tensile)
+                         ? yield_function(0)
+                         : yield_function(1);
+
   // Compute flow/yield gradients and softening contribution.
   Vector6d df_dsigma = Vector6d::Zero();
   Vector6d dp_dsigma = Vector6d::Zero();
   double dp_dq = 0.0;
   double softening_modulus = 0.0;
 
-  this->compute_df_dp(yield_type, state_vars, current_stress,
-                      &df_dsigma, &dp_dsigma, &dp_dq, &softening_modulus);
+  this->compute_df_dp(yield_type, state_vars, current_stress, &df_dsigma,
+                      &dp_dsigma, &dp_dq, &softening_modulus);
 
   // Consistency denominator:
   // n^T De m + H, where n = dF/dsigma, m = dP/dsigma, H = softening term.
-  double denominator = (df_dsigma.transpose() * de).dot(dp_dsigma) + softening_modulus;
-  
+  double denominator =
+      (df_dsigma.transpose() * de).dot(dp_dsigma) + softening_modulus;
+
   // =========================================================================
   // Denominator regularization
   // =========================================================================
   bool success = true;
   if (denominator < Min_Denominator) {
     if (denominator < -Min_Denominator) {
-      // Negative denominator indicates local instability due to strong softening.
+      // Negative denominator indicates local instability due to strong
+      // softening.
       console_->warn(
           "MohrCoulomb: Negative denominator detected ({:.6e}). "
           "This indicates material instability (strong softening). "
@@ -553,7 +557,7 @@ mpm::MohrCoulomb<Tdim>::compute_single_surface_return(
 
   // Plastic multiplier increment from first-order consistency.
   double dlambda = f_current / denominator;
-  
+
   // Physical admissibility check.
   if (dlambda < 0.0) {
     // Negative plastic multiplier is non-admissible for this active set.
@@ -563,7 +567,7 @@ mpm::MohrCoulomb<Tdim>::compute_single_surface_return(
     dlambda = 0.0;
     success = false;
   }
-  
+
   // Clamp very large multiplier increments for numerical robustness.
   const double max_dlambda = 1.0;  // Can be tuned per problem class.
   if (dlambda > max_dlambda) {
@@ -583,31 +587,33 @@ mpm::MohrCoulomb<Tdim>::compute_single_surface_return(
 
 //! Corner return mapping (multi-surface)
 //! Applies Koiter's rule when both tension and shear surfaces are active.
-//! Returns: (stress correction, plastic deviatoric strain increment, success flag)
+//! Returns: (stress correction, plastic deviatoric strain increment, success
+//! flag)
 template <unsigned Tdim>
 std::tuple<Eigen::Matrix<double, 6, 1>, double, bool>
-mpm::MohrCoulomb<Tdim>::compute_corner_return(
-    const Vector6d& current_stress,
-    const Matrix6x6& de,
-    mpm::dense_map* state_vars) {
-  
+    mpm::MohrCoulomb<Tdim>::compute_corner_return(
+        const Vector6d& current_stress, const Matrix6x6& de,
+        mpm::dense_map* state_vars) {
+
   const double Min_Denominator = 1E-15;
-  
+
   // Compute gradients for both active surfaces.
   Vector6d df_dsigma_t = Vector6d::Zero();  // Tension
   Vector6d dp_dsigma_t = Vector6d::Zero();
   double dp_dq_t = 0.0;
   double softening_t = 0.0;
-  
+
   Vector6d df_dsigma_s = Vector6d::Zero();  // Shear
   Vector6d dp_dsigma_s = Vector6d::Zero();
   double dp_dq_s = 0.0;
   double softening_s = 0.0;
 
-  this->compute_df_dp(mpm::mohrcoulomb::FailureState::Tensile, state_vars, 
-                      current_stress, &df_dsigma_t, &dp_dsigma_t, &dp_dq_t, &softening_t);
+  this->compute_df_dp(mpm::mohrcoulomb::FailureState::Tensile, state_vars,
+                      current_stress, &df_dsigma_t, &dp_dsigma_t, &dp_dq_t,
+                      &softening_t);
   this->compute_df_dp(mpm::mohrcoulomb::FailureState::Shear, state_vars,
-                      current_stress, &df_dsigma_s, &dp_dsigma_s, &dp_dq_s, &softening_s);
+                      current_stress, &df_dsigma_s, &dp_dsigma_s, &dp_dq_s,
+                      &softening_s);
 
   // Recompute yield-function values at the current stress.
   Eigen::Matrix<double, 2, 1> yield_function;
@@ -621,25 +627,25 @@ mpm::MohrCoulomb<Tdim>::compute_corner_return(
   // [A21 A22] [lambda_s] = [f_s]
   // with A_ij = n_i^T De m_j + H_i delta_ij.
   // =========================================================================
-  
+
   Eigen::Matrix<double, 2, 2> A;
   Eigen::Vector2d b;
-  
+
   // Assemble system matrix.
   Vector6d de_dp_t = de * dp_dsigma_t;
   Vector6d de_dp_s = de * dp_dsigma_s;
-  
+
   A(0, 0) = df_dsigma_t.dot(de_dp_t) + softening_t;
   A(0, 1) = df_dsigma_t.dot(de_dp_s);
   A(1, 0) = df_dsigma_s.dot(de_dp_t);
   A(1, 1) = df_dsigma_s.dot(de_dp_s) + softening_s;
-  
+
   b(0) = f_t;
   b(1) = f_s;
 
   // Check determinant for singular/ill-conditioned corner system.
   double det_A = A(0, 0) * A(1, 1) - A(0, 1) * A(1, 0);
-  
+
   if (std::abs(det_A) < Min_Denominator) {
     // Singular or near-singular system: corner return is not reliable.
     console_->debug(
@@ -651,11 +657,11 @@ mpm::MohrCoulomb<Tdim>::compute_corner_return(
 
   // Solve explicitly via inverse (closed form for 2x2).
   Eigen::Matrix<double, 2, 2> A_inv;
-  A_inv(0, 0) =  A(1, 1) / det_A;
+  A_inv(0, 0) = A(1, 1) / det_A;
   A_inv(0, 1) = -A(0, 1) / det_A;
   A_inv(1, 0) = -A(1, 0) / det_A;
-  A_inv(1, 1) =  A(0, 0) / det_A;
-  
+  A_inv(1, 1) = A(0, 0) / det_A;
+
   Eigen::Vector2d lambdas = A_inv * b;
   double lambda_t = lambdas(0);
   double lambda_s = lambdas(1);
@@ -664,13 +670,14 @@ mpm::MohrCoulomb<Tdim>::compute_corner_return(
   // Plastic multiplier admissibility checks
   // =========================================================================
   bool success = true;
-  
+
   // Check for negative multipliers.
   if (lambda_t < 0.0 || lambda_s < 0.0) {
     if (lambda_t < 0.0 && lambda_s < 0.0) {
       // Both negative: active-set assumption is invalid.
       console_->debug(
-          "MohrCoulomb: Both plastic multipliers negative (λ_t={:.6e}, λ_s={:.6e}). "
+          "MohrCoulomb: Both plastic multipliers negative (λ_t={:.6e}, "
+          "λ_s={:.6e}). "
           "Corner return failed.",
           lambda_t, lambda_s);
       return {Vector6d::Zero(), 0.0, false};
@@ -704,8 +711,9 @@ mpm::MohrCoulomb<Tdim>::compute_corner_return(
   // Stress correction by Koiter's rule:
   // Delta sigma = -De * (lambda_t * m_t + lambda_s * m_s)
   // =========================================================================
-  Vector6d stress_correction = -de * (lambda_t * dp_dsigma_t + lambda_s * dp_dsigma_s);
-  
+  Vector6d stress_correction =
+      -de * (lambda_t * dp_dsigma_t + lambda_s * dp_dsigma_s);
+
   // Equivalent plastic deviatoric strain increment from both mechanisms.
   double dpdstrain = lambda_t * dp_dq_t + lambda_s * dp_dq_s;
 
@@ -714,9 +722,10 @@ mpm::MohrCoulomb<Tdim>::compute_corner_return(
 
 //! Update softening parameters
 template <unsigned Tdim>
-void mpm::MohrCoulomb<Tdim>::update_softening_parameters(mpm::dense_map* state_vars) {
+void mpm::MohrCoulomb<Tdim>::update_softening_parameters(
+    mpm::dense_map* state_vars) {
   const double pdstrain = (*state_vars).at("pdstrain");
-  
+
   if (pdstrain <= pdstrain_peak_) {
     // Pre-peak: keep peak strength parameters.
     (*state_vars).at("phi") = phi_peak_;
@@ -729,21 +738,22 @@ void mpm::MohrCoulomb<Tdim>::update_softening_parameters(mpm::dense_map* state_v
     (*state_vars).at("cohesion") = cohesion_residual_;
   } else {
     // Linear softening law between peak and residual states.
-    const double ratio = (pdstrain - pdstrain_peak_) / 
-                         (pdstrain_residual_ - pdstrain_peak_);
+    const double ratio =
+        (pdstrain - pdstrain_peak_) / (pdstrain_residual_ - pdstrain_peak_);
     (*state_vars).at("phi") = phi_peak_ + ratio * (phi_residual_ - phi_peak_);
     (*state_vars).at("psi") = psi_peak_ + ratio * (psi_residual_ - psi_peak_);
-    (*state_vars).at("cohesion") = cohesion_peak_ + ratio * (cohesion_residual_ - cohesion_peak_);
+    (*state_vars).at("cohesion") =
+        cohesion_peak_ + ratio * (cohesion_residual_ - cohesion_peak_);
   }
-  
+
   // Enforce apex condition: sigma_t <= c / tan(phi) for MC cone closure.
   const double phi = (*state_vars).at("phi");
   const double cohesion = (*state_vars).at("cohesion");
-  
+
   // Guard against near-zero tan(phi).
   const double tan_phi = std::tan(phi);
   const double min_tan_phi = 1.0e-10;
-  
+
   double apex;
   if (std::abs(tan_phi) < min_tan_phi) {
     // For phi ~= 0, apex tends to a very large value.
@@ -751,12 +761,12 @@ void mpm::MohrCoulomb<Tdim>::update_softening_parameters(mpm::dense_map* state_v
   } else {
     apex = cohesion / tan_phi;
   }
-  
+
   // Clamp tension cutoff by apex.
   if ((*state_vars).at("tension_cutoff") > apex) {
     (*state_vars).at("tension_cutoff") = apex;
   }
-  
+
   // Keep tensile cutoff non-negative.
   if ((*state_vars).at("tension_cutoff") < 0.0) {
     (*state_vars).at("tension_cutoff") = 0.0;

--- a/include/materials/infinitesimal_strain/mohr_coulomb.tcc
+++ b/include/materials/infinitesimal_strain/mohr_coulomb.tcc
@@ -124,7 +124,7 @@ template <unsigned Tdim>
 bool mpm::MohrCoulomb<Tdim>::compute_stress_invariants(
     const Vector6d& stress, mpm::dense_map* state_vars) {
   // Compute the mean pressure
-  (*state_vars).at("pressure") = -mpm::materials::p(stress);
+  (*state_vars).at("pressure") = mpm::materials::p(stress);
   // Compute theta value
   (*state_vars).at("theta") = mpm::materials::lode_angle(stress);
   // Compute tau
@@ -142,7 +142,7 @@ typename mpm::mohrcoulomb::FailureState
   // Tolerance for yield function
   const double Tolerance = 1E-7;
   // Get stress invariants
-  const double epsilon = -state_vars.at("pressure") * std::sqrt(3.);
+  const double epsilon = state_vars.at("pressure") * std::sqrt(3.);
   const double rho = std::sqrt(2.0) * state_vars.at("tau");
   const double theta = state_vars.at("theta");
   // Get MC parameters

--- a/include/materials/infinitesimal_strain/mohr_coulomb.tcc
+++ b/include/materials/infinitesimal_strain/mohr_coulomb.tcc
@@ -124,7 +124,7 @@ template <unsigned Tdim>
 bool mpm::MohrCoulomb<Tdim>::compute_stress_invariants(
     const Vector6d& stress, mpm::dense_map* state_vars) {
   // Compute the mean pressure
-  (*state_vars).at("pressure") = mpm::materials::p(stress);
+  (*state_vars).at("pressure") = -mpm::materials::p(stress);
   // Compute theta value
   (*state_vars).at("theta") = mpm::materials::lode_angle(stress);
   // Compute tau
@@ -142,7 +142,7 @@ typename mpm::mohrcoulomb::FailureState
   // Tolerance for yield function
   const double Tolerance = 1E-7;
   // Get stress invariants
-  const double epsilon = state_vars.at("pressure") * std::sqrt(3.);
+  const double epsilon = -state_vars.at("pressure") * std::sqrt(3.);
   const double rho = std::sqrt(2.0) * state_vars.at("tau");
   const double theta = state_vars.at("theta");
   // Get MC parameters

--- a/include/materials/infinitesimal_strain/mohr_coulomb.tcc
+++ b/include/materials/infinitesimal_strain/mohr_coulomb.tcc
@@ -106,16 +106,35 @@ mpm::dense_map mpm::MohrCoulomb<Tdim>::initialise_state_variables() {
       // Theta
       {"theta", 0.},
       // Plastic deviatoric strain
-      {"pdstrain", 0.}};
+      {"pdstrain", 0.},
+      // Plastic strain components
+      {"plastic_strain0", 0.},
+      {"plastic_strain1", 0.},
+      {"plastic_strain2", 0.},
+      {"plastic_strain3", 0.},
+      {"plastic_strain4", 0.},
+      {"plastic_strain5", 0.}};
   return state_vars;
 }
 
 //! Initialise state variables
 template <unsigned Tdim>
 std::vector<std::string> mpm::MohrCoulomb<Tdim>::state_variables() const {
-  const std::vector<std::string> state_vars = {
-      "yield_state", "phi", "psi",   "cohesion", "tension_cutoff",
-      "pressure",    "tau", "theta", "pdstrain"};
+  const std::vector<std::string> state_vars = {"yield_state",
+                                               "phi",
+                                               "psi",
+                                               "cohesion",
+                                               "tension_cutoff",
+                                               "pressure",
+                                               "tau",
+                                               "theta",
+                                               "pdstrain",
+                                               "plastic_strain0",
+                                               "plastic_strain1",
+                                               "plastic_strain2",
+                                               "plastic_strain3",
+                                               "plastic_strain4",
+                                               "plastic_strain5"};
   return state_vars;
 }
 
@@ -139,16 +158,17 @@ typename mpm::mohrcoulomb::FailureState
     mpm::MohrCoulomb<Tdim>::compute_yield_state(
         Eigen::Matrix<double, 2, 1>* yield_function,
         const mpm::dense_map& state_vars) {
-  // Tolerance for yield function
-  const double Tolerance = 1E-7;
+
   // Get stress invariants
   const double epsilon = -state_vars.at("pressure") * std::sqrt(3.);
   const double rho = std::sqrt(2.0) * state_vars.at("tau");
   const double theta = state_vars.at("theta");
+
   // Get MC parameters
   const double phi = state_vars.at("phi");
   const double cohesion = state_vars.at("cohesion");
   const double tension_cutoff = state_vars.at("tension_cutoff");
+
   // Compute yield functions (tension & shear)
   // Tension
   (*yield_function)(0) = std::sqrt(2. / 3.) * cos(theta) * rho +
@@ -159,32 +179,17 @@ typename mpm::mohrcoulomb::FailureState
           ((sin(theta + M_PI / 3.) / (std::sqrt(3.) * cos(phi))) +
            (cos(theta + M_PI / 3.) * tan(phi) / 3.)) +
       (epsilon / std::sqrt(3.)) * tan(phi) - cohesion;
+
   // Initialise yield status (0: elastic, 1: shear failure, 2: tensile failure)
   auto yield_type = mpm::mohrcoulomb::FailureState::Elastic;
   // Check for tension and shear
-  if ((*yield_function)(0) > Tolerance && (*yield_function)(1) > Tolerance) {
-    // Compute tension and shear edge parameters
-    const double n_phi = (1. + sin(phi)) / (1. - sin(phi));
-    const double sigma_p =
-        tension_cutoff * n_phi - 2. * cohesion * std::sqrt(n_phi);
-    const double alpha_p = std::sqrt(1. + n_phi * n_phi) + n_phi;
-    // Compute the shear-tension edge
-    const double h =
-        (*yield_function)(0) +
-        alpha_p * (std::sqrt(2. / 3.) * cos(theta - 4. * M_PI / 3.) * rho +
-                   epsilon / std::sqrt(3.) - sigma_p);
-    // Tension
-    if (h > std::numeric_limits<double>::epsilon())
-      yield_type = mpm::mohrcoulomb::FailureState::Tensile;
-    // Shear
-    else
-      yield_type = mpm::mohrcoulomb::FailureState::Shear;
-  }
+  if ((*yield_function)(0) > 0.0 && (*yield_function)(1) > 0.0)
+    yield_type = mpm::mohrcoulomb::FailureState::ShearTensile;
   // Shear failure
-  if ((*yield_function)(0) < Tolerance && (*yield_function)(1) > Tolerance)
+  if ((*yield_function)(0) <= 0.0 && (*yield_function)(1) > 0.0)
     yield_type = mpm::mohrcoulomb::FailureState::Shear;
   // Tension failure
-  if ((*yield_function)(0) > Tolerance && (*yield_function)(1) < Tolerance)
+  if ((*yield_function)(0) > 0.0 && (*yield_function)(1) <= 0.0)
     yield_type = mpm::mohrcoulomb::FailureState::Tensile;
 
   return yield_type;
@@ -195,7 +200,7 @@ template <unsigned Tdim>
 void mpm::MohrCoulomb<Tdim>::compute_df_dp(
     mpm::mohrcoulomb::FailureState yield_type, const mpm::dense_map* state_vars,
     const Vector6d& stress, Vector6d* df_dsigma, Vector6d* dp_dsigma,
-    double* dp_dq, double* softening) {
+    double* dp_dq, double* softening, double pdstrain) {
   // Get stress invariants
   const double rho = std::sqrt(2.0) * (*state_vars).at("tau");
   const double theta = (*state_vars).at("theta");
@@ -203,8 +208,7 @@ void mpm::MohrCoulomb<Tdim>::compute_df_dp(
   const double phi = (*state_vars).at("phi");
   const double psi = (*state_vars).at("psi");
   const double tension_cutoff = (*state_vars).at("tension_cutoff");
-  // Get equivalent plastic deviatoric strain
-  const double pdstrain = (*state_vars).at("pdstrain");
+
   // Compute dF / dEpsilon,  dF / dRho, dF / dTheta
   double df_depsilon, df_drho, df_dtheta;
   // Values in tension yield
@@ -214,7 +218,7 @@ void mpm::MohrCoulomb<Tdim>::compute_df_dp(
     df_dtheta = -std::sqrt(2. / 3.) * rho * sin(theta);
   }
   // Values in shear yield / elastic
-  else {
+  else if (yield_type == mpm::mohrcoulomb::FailureState::Shear) {
     df_depsilon = tan(phi) / std::sqrt(3.);
     df_drho = std::sqrt(1.5) *
               ((sin(theta + M_PI / 3.) / (std::sqrt(3.) * cos(phi))) +
@@ -222,7 +226,12 @@ void mpm::MohrCoulomb<Tdim>::compute_df_dp(
     df_dtheta = std::sqrt(1.5) * rho *
                 ((cos(theta + M_PI / 3.) / (std::sqrt(3.) * cos(phi))) -
                  (sin(theta + M_PI / 3.) * tan(phi) / 3.));
+  } else {
+    // Throw error for other yield types
+    console_->error("Invalid yield type for compute_df_dp: {}\n",
+                    static_cast<int>(yield_type));
   }
+
   // Compute dEpsilon / dSigma
   Vector6d depsilon_dsigma = mpm::materials::dp_dsigma() * std::sqrt(3.);
   // Initialise dRho / dSigma
@@ -233,6 +242,7 @@ void mpm::MohrCoulomb<Tdim>::compute_df_dp(
   // Compute dF/dSigma
   (*df_dsigma) = (df_depsilon * depsilon_dsigma) + (df_drho * drho_dsigma) +
                  (df_dtheta * dtheta_dsigma);
+
   // Compute dp/dsigma and dp/dj in tension yield
   if (yield_type == mpm::mohrcoulomb::FailureState::Tensile) {
     // Define deviatoric eccentricity
@@ -281,7 +291,7 @@ void mpm::MohrCoulomb<Tdim>::compute_df_dp(
     (*dp_dq) = dp_drho * std::sqrt(2. / 3.);
   }
   // Compute dp/dsigma and dp/dj in shear yield
-  else {
+  else if (yield_type == mpm::mohrcoulomb::FailureState::Shear) {
     // Compute Rmc
     const double r_mc = (3. - sin(phi)) / (6 * cos(phi));
     // Compute deviatoric eccentricity
@@ -318,18 +328,17 @@ void mpm::MohrCoulomb<Tdim>::compute_df_dp(
                    (dp_dtheta * dtheta_dsigma);
     (*dp_dq) = dp_drho * std::sqrt(2. / 3.);
   }
+
   // Compute softening part
-  double dphi_dpstrain = 0.;
-  double dc_dpstrain = 0.;
   (*softening) = 0.;
   if (softening_ && pdstrain > pdstrain_peak_ &&
       pdstrain < pdstrain_residual_) {
     // Compute dPhi/dPstrain
-    dphi_dpstrain =
+    double dphi_dpstrain =
         (phi_residual_ - phi_peak_) / (pdstrain_residual_ - pdstrain_peak_);
     // Compute dc/dPstrain
-    dc_dpstrain = (cohesion_residual_ - cohesion_peak_) /
-                  (pdstrain_residual_ - pdstrain_peak_);
+    double dc_dpstrain = (cohesion_residual_ - cohesion_peak_) /
+                         (pdstrain_residual_ - pdstrain_peak_);
     // Compute dF/dPstrain
     double df_dphi =
         std::sqrt(1.5) * rho *
@@ -342,16 +351,11 @@ void mpm::MohrCoulomb<Tdim>::compute_df_dp(
         (-1.) * ((df_dphi * dphi_dpstrain) + (df_dc * dc_dpstrain)) * (*dp_dq);
   }
 }
+
 template <unsigned Tdim>
 Eigen::Matrix<double, 6, 1> mpm::MohrCoulomb<Tdim>::compute_stress(
     const Vector6d& stress, const Vector6d& dstrain,
     const ParticleBase<Tdim>* ptr, mpm::dense_map* state_vars, double dt) {
-
-  // =========================================================================
-  // 1. Constants and initialization
-  // =========================================================================
-  const double Tolerance = 1E-7;  // Yield-function tolerance
-  const unsigned itr_max = 50;    // Maximum return-mapping iterations
 
   // Check density criterion for tensile separation.
   const double current_packing_density = ptr->mass_density();
@@ -362,13 +366,15 @@ Eigen::Matrix<double, 6, 1> mpm::MohrCoulomb<Tdim>::compute_stress(
   Matrix6x6 de = this->compute_elastic_tensor(state_vars);
   Vector6d trial_stress =
       this->compute_trial_stress(stress, dstrain, de, ptr, state_vars);
+
   // Separated state: current packing density is less than critical density
   if (current_packing_density <= critical_density) {
     (*state_vars).at("pdstrain") +=
         mpm::materials::q(trial_stress) / 3.0 / shear_modulus_;
-    (*state_vars).at("yield_state") = 3;
+    (*state_vars).at("yield_state") = 4;
     return Vector6d::Zero();
   }
+
   // Compute stress invariants based on trial stress
   this->compute_stress_invariants(trial_stress, state_vars);
 
@@ -377,26 +383,79 @@ Eigen::Matrix<double, 6, 1> mpm::MohrCoulomb<Tdim>::compute_stress(
   auto yield_type = this->compute_yield_state(&yield_function, (*state_vars));
 
   // Elastic admissibility: if both surfaces are satisfied, accept trial stress.
-  if (yield_function(0) <= Tolerance && yield_function(1) <= Tolerance) {
+  if (yield_type == mpm::mohrcoulomb::FailureState::Elastic) {
     (*state_vars).at("yield_state") = 0;
     return trial_stress;
   }
 
-  // =========================================================================
-  // 3. Plastic corrector (cutting-plane + corner return)
-  //
-  // The stress is projected back to the admissible domain by incremental
-  // return mapping. A single violated surface uses one plastic multiplier;
-  // simultaneous tension/shear violation uses a multi-surface corner return.
-  // =========================================================================
-
-  Vector6d current_stress = trial_stress;
+  // If plastic, do return mapping
   bool converged = false;
+  Vector6d current_stress = trial_stress;
+  Vector6d dstrain_p_tensile = Vector6d::Zero();
+  Vector6d dstrain_p_shear = Vector6d::Zero();
+  Eigen::Matrix<double, 2, 1> unknowns =
+      Eigen::Matrix<double, 2, 1>::Constant(tolerance_);
+  Eigen::Matrix<double, 2, 1> dlambda = Vector2d::Zero();
 
-  for (unsigned itr = 0; itr < itr_max; ++itr) {
-    // ---------------------------------------------------------------------
-    // A. Re-evaluate invariants and active surface at current stress.
-    // ---------------------------------------------------------------------
+  // Updated state variables for return mapping iterations
+  Vector6d plastic_strain = Vector6d::Zero();
+  plastic_strain(0) = (*state_vars).at("plastic_strain0");
+  plastic_strain(1) = (*state_vars).at("plastic_strain1");
+  plastic_strain(2) = (*state_vars).at("plastic_strain2");
+  plastic_strain(3) = (*state_vars).at("plastic_strain3");
+  plastic_strain(4) = (*state_vars).at("plastic_strain4");
+  plastic_strain(5) = (*state_vars).at("plastic_strain5");
+  double pdstrain = (*state_vars).at("pdstrain");
+
+  // Start newton raphson return mapping iterations
+  for (unsigned itr = 0; itr < max_iter_; ++itr) {
+    Vector6d stress_correction = Vector6d::Zero();
+
+    // Return mapping in the shear-tensile region
+    if (yield_type == mpm::mohrcoulomb::FailureState::ShearTensile) {
+      auto [corner_correction, dstrain_p_tensile, dstrain_p_shear] =
+          this->compute_corner_return(current_stress, de, state_vars,
+                                      yield_function, unknowns, dlambda,
+                                      pdstrain);
+      stress_correction = corner_correction;
+    } else {
+      double yield_function_single =
+          (yield_type == mpm::mohrcoulomb::FailureState::Tensile)
+              ? yield_function(0)
+              : yield_function(1);
+      double u_single = (yield_type == mpm::mohrcoulomb::FailureState::Tensile)
+                            ? unknowns(0)
+                            : unknowns(1);
+      double dlambda_single =
+          (yield_type == mpm::mohrcoulomb::FailureState::Tensile) ? dlambda(0)
+                                                                  : dlambda(1);
+
+      auto [single_correction, dstrain_p] = this->compute_single_surface_return(
+          yield_type, yield_function_single, current_stress, de, state_vars,
+          u_single, dlambda_single, pdstrain);
+      stress_correction = single_correction;
+      if (yield_type == mpm::mohrcoulomb::FailureState::Tensile) {
+        dstrain_p_tensile = dstrain_p;
+        unknowns(0) = u_single;
+        dlambda(0) = dlambda_single;
+      } else {
+        dstrain_p_shear = dstrain_p;
+        unknowns(1) = u_single;
+        dlambda(1) = dlambda_single;
+      }
+    }
+
+    // Update stress and plastic strain
+    current_stress = trial_stress + stress_correction;
+    new_plastic_strain = plastic_strain + dstrain_p_shear + dstrain_p_tensile;
+    pdstrain = mpm::materials::pdstrain(new_plastic_strain);
+
+    // Update softening-dependent strength parameters.
+    if (softening_) {
+      this->update_softening_parameters(state_vars);
+    }
+
+    // Re-evaluate invariants and active surface at current stress.
     this->compute_stress_invariants(current_stress, state_vars);
     yield_type = this->compute_yield_state(&yield_function, (*state_vars));
 
@@ -416,68 +475,6 @@ Eigen::Matrix<double, 6, 1> mpm::MohrCoulomb<Tdim>::compute_stress(
       }
       break;
     }
-
-    // ---------------------------------------------------------------------
-    // C. Determine active mechanism and choose return strategy.
-    // ---------------------------------------------------------------------
-    const bool tension_violated = (yield_function(0) > Tolerance);
-    const bool shear_violated = (yield_function(1) > Tolerance);
-
-    Vector6d stress_correction = Vector6d::Zero();
-    double dpdstrain_inc = 0.0;
-
-    if (tension_violated && shear_violated) {
-      // =================================================================
-      // Corner return mapping (multi-surface plasticity)
-      // Used when both tension and shear surfaces are violated.
-      // =================================================================
-      auto [corner_correction, corner_dpdstrain, corner_success] =
-          this->compute_corner_return(current_stress, de, state_vars);
-
-      if (corner_success) {
-        stress_correction = corner_correction;
-        dpdstrain_inc = corner_dpdstrain;
-      } else {
-        // If corner return fails, fall back to single-surface return on the
-        // most violated surface.
-        if (yield_function(0) > yield_function(1)) {
-          yield_type = mpm::mohrcoulomb::FailureState::Tensile;
-        } else {
-          yield_type = mpm::mohrcoulomb::FailureState::Shear;
-        }
-        const auto single_return = this->compute_single_surface_return(
-            yield_type, yield_function, current_stress, de, state_vars);
-        stress_correction = std::get<0>(single_return);
-        dpdstrain_inc = std::get<1>(single_return);
-      }
-    } else {
-      // =================================================================
-      // Single-surface return mapping
-      // =================================================================
-      if (tension_violated) {
-        yield_type = mpm::mohrcoulomb::FailureState::Tensile;
-        (*state_vars).at("yield_state") = 2;
-      } else {
-        yield_type = mpm::mohrcoulomb::FailureState::Shear;
-        (*state_vars).at("yield_state") = 1;
-      }
-
-      const auto single_return = this->compute_single_surface_return(
-          yield_type, yield_function, current_stress, de, state_vars);
-      stress_correction = std::get<0>(single_return);
-      dpdstrain_inc = std::get<1>(single_return);
-    }
-
-    // ---------------------------------------------------------------------
-    // D. Update stress and internal variable.
-    // ---------------------------------------------------------------------
-    current_stress += stress_correction;
-    (*state_vars).at("pdstrain") += dpdstrain_inc;
-
-    // Update softening-dependent strength parameters.
-    if (softening_) {
-      this->update_softening_parameters(state_vars);
-    }
   }
 
   // =========================================================================
@@ -488,7 +485,7 @@ Eigen::Matrix<double, 6, 1> mpm::MohrCoulomb<Tdim>::compute_stress(
     console_->warn(
         "MohrCoulomb::compute_stress: Return mapping did not converge "
         "after {} iterations. Final yield functions: f_t = {}, f_s = {}",
-        itr_max, yield_function(0), yield_function(1));
+        max_iter_, yield_function(0), yield_function(1));
   }
 
   // Store final stress invariants.
@@ -496,23 +493,20 @@ Eigen::Matrix<double, 6, 1> mpm::MohrCoulomb<Tdim>::compute_stress(
 
   return current_stress;
 }
+
 //! Single-surface return mapping
 //! Returns: (stress correction, plastic deviatoric strain increment, success
 //! flag)
 template <unsigned Tdim>
-std::tuple<Eigen::Matrix<double, 6, 1>, double, bool>
+std::tuple<Eigen::Matrix<double, 6, 1>, Eigen::Matrix<double, 6, 1>>
     mpm::MohrCoulomb<Tdim>::compute_single_surface_return(
-        mpm::mohrcoulomb::FailureState yield_type,
-        const Eigen::Matrix<double, 2, 1>& yield_function,
+        mpm::mohrcoulomb::FailureState yield_type, double yield_function,
         const Vector6d& current_stress, const Matrix6x6& de,
-        mpm::dense_map* state_vars) {
-
-  const double Min_Denominator = 1E-15;
+        mpm::dense_map* state_vars, double& u_single, double& dlambda_single,
+        double pdstrain) {
 
   // Select active yield-function value on the current surface.
-  double f_current = (yield_type == mpm::mohrcoulomb::FailureState::Tensile)
-                         ? yield_function(0)
-                         : yield_function(1);
+  double f_current = yield_function;
 
   // Compute flow/yield gradients and softening contribution.
   Vector6d df_dsigma = Vector6d::Zero();
@@ -521,80 +515,45 @@ std::tuple<Eigen::Matrix<double, 6, 1>, double, bool>
   double softening_modulus = 0.0;
 
   this->compute_df_dp(yield_type, state_vars, current_stress, &df_dsigma,
-                      &dp_dsigma, &dp_dq, &softening_modulus);
+                      &dp_dsigma, &dp_dq, &softening_modulus, pdstrain);
 
   // Consistency denominator:
   // n^T De m + H, where n = dF/dsigma, m = dP/dsigma, H = softening term.
   double denominator =
-      (df_dsigma.transpose() * de).dot(dp_dsigma) + softening_modulus;
+      2.0 * u_single * (df_dsigma.transpose() * de).dot(dp_dsigma) +
+      softening_modulus;
 
-  // =========================================================================
-  // Denominator regularization
-  // =========================================================================
-  bool success = true;
-  if (denominator < Min_Denominator) {
-    if (denominator < -Min_Denominator) {
-      // Negative denominator indicates local instability due to strong
-      // softening.
-      console_->warn(
-          "MohrCoulomb: Negative denominator detected ({:.6e}). "
-          "This indicates material instability (strong softening). "
-          "Using regularization.",
-          denominator);
-      // Regularize to a small positive value.
-      denominator = Min_Denominator;
-      success = false;  // Mark partially successful correction.
-    } else {
-      // Near-zero denominator implies numerical singularity.
-      console_->debug(
-          "MohrCoulomb: Near-zero denominator detected ({:.6e}). "
-          "Applying regularization.",
-          denominator);
-      denominator = Min_Denominator;
-    }
+  if (std::abs(denominator) < std::numeric_limits<double>::epsilon()) {
+    console_->warn(
+        "MohrCoulomb: Consistency denominator is near zero ({:.6e}). "
+        "This may indicate numerical instability. Applying regularization.",
+        denominator);
+    denominator = check_low(denominator, 1e-5);
   }
 
   // Plastic multiplier increment from first-order consistency.
-  double dlambda = f_current / denominator;
-
-  // Physical admissibility check.
-  if (dlambda < 0.0) {
-    // Negative plastic multiplier is non-admissible for this active set.
-    console_->warn(
-        "MohrCoulomb: Negative plastic multiplier ({:.6e}). Setting to zero.",
-        dlambda);
-    dlambda = 0.0;
-    success = false;
-  }
-
-  // Clamp very large multiplier increments for numerical robustness.
-  const double max_dlambda = 1.0;  // Can be tuned per problem class.
-  if (dlambda > max_dlambda) {
-    console_->debug(
-        "MohrCoulomb: Large plastic multiplier ({:.6e}). Clamping to {:.6e}.",
-        dlambda, max_dlambda);
-    dlambda = max_dlambda;
-  }
+  double d_u = -f_current / denominator;
+  u_single += d_u;
+  dlambda_single = u_single * u_single;
 
   // Stress update: Delta sigma = -dlambda * De * dP/dsigma.
   Vector6d stress_correction = -dlambda * de * dp_dsigma;
-  // Internal variable increment from equivalent plastic deviatoric measure.
-  double dpdstrain = dlambda * dp_dq;
+  // Plastic strain increment
+  Vector6d dstrain_p = dlambda * dp_dsigma;
 
-  return {stress_correction, dpdstrain, success};
+  return {stress_correction, dstrain_p};
 }
 
 //! Corner return mapping (multi-surface)
-//! Applies Koiter's rule when both tension and shear surfaces are active.
-//! Returns: (stress correction, plastic deviatoric strain increment, success
-//! flag)
 template <unsigned Tdim>
-std::tuple<Eigen::Matrix<double, 6, 1>, double, bool>
+std::tuple<Eigen::Matrix<double, 6, 1>, Eigen::Matrix<double, 6, 1>,
+           Eigen::Matrix<double, 6, 1>>
     mpm::MohrCoulomb<Tdim>::compute_corner_return(
         const Vector6d& current_stress, const Matrix6x6& de,
-        mpm::dense_map* state_vars) {
-
-  const double Min_Denominator = 1E-15;
+        mpm::dense_map* state_vars,
+        const Eigen::Matrix<double, 2, 1>& yield_function,
+        Eigen::Matrix<double, 2, 1>& unknowns,
+        Eigen::Matrix<double, 2, 1>& dlambda, double pdstrain) {
 
   // Compute gradients for both active surfaces.
   Vector6d df_dsigma_t = Vector6d::Zero();  // Tension
@@ -609,14 +568,12 @@ std::tuple<Eigen::Matrix<double, 6, 1>, double, bool>
 
   this->compute_df_dp(mpm::mohrcoulomb::FailureState::Tensile, state_vars,
                       current_stress, &df_dsigma_t, &dp_dsigma_t, &dp_dq_t,
-                      &softening_t);
+                      &softening_t, pdstrain);
   this->compute_df_dp(mpm::mohrcoulomb::FailureState::Shear, state_vars,
                       current_stress, &df_dsigma_s, &dp_dsigma_s, &dp_dq_s,
-                      &softening_s);
+                      &softening_s, pdstrain);
 
   // Recompute yield-function values at the current stress.
-  Eigen::Matrix<double, 2, 1> yield_function;
-  this->compute_yield_state(&yield_function, (*state_vars));
   const double f_t = yield_function(0);  // Tension
   const double f_s = yield_function(1);  // Shear
 
@@ -626,7 +583,6 @@ std::tuple<Eigen::Matrix<double, 6, 1>, double, bool>
   // [A21 A22] [lambda_s] = [f_s]
   // with A_ij = n_i^T De m_j + H_i delta_ij.
   // =========================================================================
-
   Eigen::Matrix<double, 2, 2> A;
   Eigen::Vector2d b;
 
@@ -645,14 +601,20 @@ std::tuple<Eigen::Matrix<double, 6, 1>, double, bool>
   // Check determinant for singular/ill-conditioned corner system.
   double det_A = A(0, 0) * A(1, 1) - A(0, 1) * A(1, 0);
 
-  if (std::abs(det_A) < Min_Denominator) {
+  if (std::abs(det_A) < std::numeric_limits<double>::epsilon()) {
     // Singular or near-singular system: corner return is not reliable.
-    console_->debug(
+    console_->error(
         "MohrCoulomb: Corner return matrix is singular (det = {:.6e}). "
         "Falling back to single surface return.",
         det_A);
-    return {Vector6d::Zero(), 0.0, false};
+    return {Vector6d::Zero(), Vector6d::Zero(), Vector6d::Zero()};
   }
+
+  // Quadratic transformation to ensure positive lambdas
+  A(0, 0) *= 2.0 * unknowns(0);
+  A(0, 1) *= 2.0 * unknowns(1);
+  A(1, 0) *= 2.0 * unknowns(0);
+  A(1, 1) *= 2.0 * unknowns(1);
 
   // Solve explicitly via inverse (closed form for 2x2).
   Eigen::Matrix<double, 2, 2> A_inv;
@@ -661,70 +623,34 @@ std::tuple<Eigen::Matrix<double, 6, 1>, double, bool>
   A_inv(1, 0) = -A(1, 0) / det_A;
   A_inv(1, 1) = A(0, 0) / det_A;
 
-  Eigen::Vector2d lambdas = A_inv * b;
-  double lambda_t = lambdas(0);
-  double lambda_s = lambdas(1);
+  Eigen::Vector2d delta_u = -A_inv * b;
+  unknowns += delta_u;
+  dlambda(0) = unknowns(0) * unknowns(0);
+  dlambda(1) = unknowns(1) * unknowns(1);
 
   // =========================================================================
   // Plastic multiplier admissibility checks
   // =========================================================================
   bool success = true;
 
-  // Check for negative multipliers.
-  if (lambda_t < 0.0 || lambda_s < 0.0) {
-    if (lambda_t < 0.0 && lambda_s < 0.0) {
-      // Both negative: active-set assumption is invalid.
-      console_->debug(
-          "MohrCoulomb: Both plastic multipliers negative (λ_t={:.6e}, "
-          "λ_s={:.6e}). "
-          "Corner return failed.",
-          lambda_t, lambda_s);
-      return {Vector6d::Zero(), 0.0, false};
-    } else if (lambda_t < 0.0) {
-      // Negative tension multiplier: prefer single shear-surface return.
-      console_->debug(
-          "MohrCoulomb: Tension plastic multiplier negative. "
-          "Should use single shear surface return.");
-      return {Vector6d::Zero(), 0.0, false};
-    } else {
-      // Negative shear multiplier: prefer single tension-surface return.
-      console_->debug(
-          "MohrCoulomb: Shear plastic multiplier negative. "
-          "Should use single tension surface return.");
-      return {Vector6d::Zero(), 0.0, false};
-    }
-  }
-
-  // Clamp excessively large multipliers.
-  const double max_lambda = 1.0;
-  if (lambda_t > max_lambda) {
-    lambda_t = max_lambda;
-    success = false;
-  }
-  if (lambda_s > max_lambda) {
-    lambda_s = max_lambda;
-    success = false;
-  }
-
   // =========================================================================
   // Stress correction by Koiter's rule:
   // Delta sigma = -De * (lambda_t * m_t + lambda_s * m_s)
   // =========================================================================
   Vector6d stress_correction =
-      -de * (lambda_t * dp_dsigma_t + lambda_s * dp_dsigma_s);
+      -de * (dlambda(0) * dp_dsigma_t + dlambda(1) * dp_dsigma_s);
 
-  // Equivalent plastic deviatoric strain increment from both mechanisms.
-  double dpdstrain = lambda_t * dp_dq_t + lambda_s * dp_dq_s;
+  // Plastic strain increment from each mechanism.
+  Vector6d dstrain_p_tensile = dlambda(0) * dp_dsigma_t;
+  Vector6d dstrain_p_shear = dlambda(1) * dp_dsigma_s;
 
-  return {stress_correction, dpdstrain, success};
+  return {stress_correction, dstrain_p_tensile, dstrain_p_shear, success};
 }
 
 //! Update softening parameters
 template <unsigned Tdim>
 void mpm::MohrCoulomb<Tdim>::update_softening_parameters(
-    mpm::dense_map* state_vars) {
-  const double pdstrain = (*state_vars).at("pdstrain");
-
+    mpm::dense_map* state_vars, double pdstrain) {
   if (pdstrain <= pdstrain_peak_) {
     // Pre-peak: keep peak strength parameters.
     (*state_vars).at("phi") = phi_peak_;

--- a/tests/materials/mohr_coulomb_test.cc
+++ b/tests/materials/mohr_coulomb_test.cc
@@ -118,8 +118,8 @@ TEST_CASE("MohrCoulomb is checked in 2D (cohesion only, without softening)",
               Approx(jmaterial["dilation"]).epsilon(Tolerance));
       REQUIRE(state_variables.at("cohesion") ==
               Approx(jmaterial["cohesion"]).epsilon(Tolerance));
-      REQUIRE(state_variables.at("epsilon") == Approx(0.).epsilon(Tolerance));
-      REQUIRE(state_variables.at("rho") == Approx(0.).epsilon(Tolerance));
+      REQUIRE(state_variables.at("pressure") == Approx(0.).epsilon(Tolerance));
+      REQUIRE(state_variables.at("tau") == Approx(0.).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") == Approx(0.).epsilon(Tolerance));
       REQUIRE(state_variables.at("pdstrain") == Approx(0.).epsilon(Tolerance));
       REQUIRE(state_variables.at("tension_cutoff") ==
@@ -129,7 +129,7 @@ TEST_CASE("MohrCoulomb is checked in 2D (cohesion only, without softening)",
 
       const std::vector<std::string> state_vars = {
           "yield_state", "phi", "psi",   "cohesion", "tension_cutoff",
-          "epsilon",     "rho", "theta", "pdstrain"};
+          "pressure",    "tau", "theta", "pdstrain"};
       auto state_vars_test = material->state_variables();
       REQUIRE(state_vars == state_vars_test);
     }
@@ -308,9 +308,9 @@ TEST_CASE("MohrCoulomb is checked in 2D (cohesion only, without softening)",
             Approx(jmaterial["dilation"]).epsilon(Tolerance));
     REQUIRE(state_variables.at("cohesion") ==
             Approx(jmaterial["cohesion"]).epsilon(Tolerance));
-    REQUIRE(state_variables.at("epsilon") ==
-            Approx(-10392.30484541).epsilon(Tolerance));
-    REQUIRE(state_variables.at("rho") == Approx(2000.).epsilon(Tolerance));
+    REQUIRE(state_variables.at("pressure") ==
+            Approx(-6000.0).epsilon(Tolerance));
+    REQUIRE(state_variables.at("tau") == Approx(1414.21356237).epsilon(Tolerance));
     REQUIRE(state_variables.at("theta") ==
             Approx(0.13545926).epsilon(Tolerance));
     REQUIRE(state_variables.at("pdstrain") == Approx(0.).epsilon(Tolerance));
@@ -369,10 +369,10 @@ TEST_CASE("MohrCoulomb is checked in 2D (cohesion only, without softening)",
               Approx(jmaterial["dilation"]).epsilon(Tolerance));
       REQUIRE(state_variables.at("cohesion") ==
               Approx(jmaterial["cohesion"]).epsilon(Tolerance));
-      REQUIRE(state_variables.at("epsilon") ==
-              Approx(-24826.06157515).epsilon(Tolerance));
-      REQUIRE(state_variables.at("rho") ==
-              Approx(5297.46320146).epsilon(Tolerance));
+      REQUIRE(state_variables.at("pressure") ==
+              Approx(-14333.33333333).epsilon(Tolerance));
+      REQUIRE(state_variables.at("tau") ==
+              Approx(3745.87215284).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") ==
               Approx(0.89359516).epsilon(Tolerance));
       REQUIRE(state_variables.at("pdstrain") == Approx(0.).epsilon(Tolerance));
@@ -475,10 +475,10 @@ TEST_CASE("MohrCoulomb is checked in 2D (cohesion only, without softening)",
               Approx(jmaterial["dilation"]).epsilon(Tolerance));
       REQUIRE(state_variables.at("cohesion") ==
               Approx(jmaterial["cohesion"]).epsilon(Tolerance));
-      REQUIRE(state_variables.at("epsilon") ==
-              Approx(4041.45188433).epsilon(Tolerance));
-      REQUIRE(state_variables.at("rho") ==
-              Approx(7670.22471249).epsilon(Tolerance));
+      REQUIRE(state_variables.at("pressure") ==
+              Approx(2333.333333).epsilon(Tolerance));
+      REQUIRE(state_variables.at("tau") ==
+              Approx(5423.6679074239).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") ==
               Approx(0.08181078).epsilon(Tolerance));
       REQUIRE(state_variables.at("pdstrain") == Approx(0.).epsilon(Tolerance));
@@ -619,10 +619,10 @@ TEST_CASE("MohrCoulomb is checked in 2D (cohesion only, without softening)",
             Approx(jmaterial["dilation"]).epsilon(Tolerance));
     REQUIRE(state_variables.at("cohesion") ==
             Approx(jmaterial["cohesion"]).epsilon(Tolerance));
-    REQUIRE(state_variables.at("epsilon") ==
-            Approx(-7505.55349947).epsilon(Tolerance));
-    REQUIRE(state_variables.at("rho") ==
-            Approx(2943.92028878).epsilon(Tolerance));
+    REQUIRE(state_variables.at("pressure") ==
+            Approx(-4333.33333333).epsilon(Tolerance));
+    REQUIRE(state_variables.at("tau") ==
+            Approx(2081.66599947).epsilon(Tolerance));
     REQUIRE(state_variables.at("theta") ==
             Approx(0.24256387).epsilon(Tolerance));
     REQUIRE(state_variables.at("pdstrain") == Approx(0.).epsilon(Tolerance));
@@ -681,10 +681,10 @@ TEST_CASE("MohrCoulomb is checked in 2D (cohesion only, without softening)",
               Approx(jmaterial["dilation"]).epsilon(Tolerance));
       REQUIRE(state_variables.at("cohesion") ==
               Approx(jmaterial["cohesion"]).epsilon(Tolerance));
-      REQUIRE(state_variables.at("epsilon") ==
-              Approx(6928.20323028).epsilon(Tolerance));
-      REQUIRE(state_variables.at("rho") ==
-              Approx(9165.79698223).epsilon(Tolerance));
+      REQUIRE(state_variables.at("pressure") ==
+              Approx(4000.).epsilon(Tolerance));
+      REQUIRE(state_variables.at("tau") ==
+              Approx(6481.19720111).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") ==
               Approx(0.07722297).epsilon(Tolerance));
       REQUIRE(state_variables.at("pdstrain") == Approx(0.).epsilon(Tolerance));
@@ -859,9 +859,9 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi, without softening)",
             Approx(jmaterial["dilation"]).epsilon(Tolerance));
     REQUIRE(state_variables.at("cohesion") ==
             Approx(jmaterial["cohesion"]).epsilon(Tolerance));
-    REQUIRE(state_variables.at("epsilon") ==
-            Approx(-10392.30484541).epsilon(Tolerance));
-    REQUIRE(state_variables.at("rho") == Approx(2000.).epsilon(Tolerance));
+    REQUIRE(state_variables.at("pressure") ==
+            Approx(-6000.).epsilon(Tolerance));
+    REQUIRE(state_variables.at("tau") == Approx(1414.21356237).epsilon(Tolerance));
     REQUIRE(state_variables.at("theta") ==
             Approx(0.13545926).epsilon(Tolerance));
     REQUIRE(state_variables.at("pdstrain") == Approx(0.).epsilon(Tolerance));
@@ -923,10 +923,10 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi, without softening)",
               Approx(jmaterial["dilation"]).epsilon(Tolerance));
       REQUIRE(state_variables.at("cohesion") ==
               Approx(jmaterial["cohesion"]).epsilon(Tolerance));
-      REQUIRE(state_variables.at("epsilon") ==
-              Approx(-8948.92917244).epsilon(Tolerance));
-      REQUIRE(state_variables.at("rho") ==
-              Approx(9669.89676021).epsilon(Tolerance));
+      REQUIRE(state_variables.at("pressure") ==
+              Approx(-5166.66666667).epsilon(Tolerance));
+      REQUIRE(state_variables.at("tau") ==
+              Approx(6837.64957252).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") ==
               Approx(0.36378823).epsilon(Tolerance));
       REQUIRE(state_variables.at("pdstrain") == Approx(0.).epsilon(Tolerance));
@@ -1026,10 +1026,10 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi, without softening)",
               Approx(jmaterial["dilation"]).epsilon(Tolerance));
       REQUIRE(state_variables.at("cohesion") ==
               Approx(jmaterial["cohesion"]).epsilon(Tolerance));
-      REQUIRE(state_variables.at("epsilon") ==
-              Approx(4041.45188433).epsilon(Tolerance));
-      REQUIRE(state_variables.at("rho") ==
-              Approx(7670.22471249).epsilon(Tolerance));
+      REQUIRE(state_variables.at("pressure") ==
+              Approx(2333.333333).epsilon(Tolerance));
+      REQUIRE(state_variables.at("tau") ==
+              Approx(5423.66790743).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") ==
               Approx(0.08181078).epsilon(Tolerance));
       REQUIRE(state_variables.at("pdstrain") == Approx(0.).epsilon(Tolerance));
@@ -1169,10 +1169,10 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi, without softening)",
             Approx(jmaterial["dilation"]).epsilon(Tolerance));
     REQUIRE(state_variables.at("cohesion") ==
             Approx(jmaterial["cohesion"]).epsilon(Tolerance));
-    REQUIRE(state_variables.at("epsilon") ==
-            Approx(-10350.85296109).epsilon(Tolerance));
-    REQUIRE(state_variables.at("rho") ==
-            Approx(6436.54117983).epsilon(Tolerance));
+    REQUIRE(state_variables.at("pressure") ==
+            Approx(-5976.06774343).epsilon(Tolerance));
+    REQUIRE(state_variables.at("tau") ==
+            Approx(4551.32191564).epsilon(Tolerance));
     REQUIRE(state_variables.at("theta") ==
             Approx(0.32751078).epsilon(Tolerance));
     REQUIRE(state_variables.at("pdstrain") == Approx(0.).epsilon(Tolerance));
@@ -1232,10 +1232,10 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi, without softening)",
               Approx(jmaterial["dilation"]).epsilon(Tolerance));
       REQUIRE(state_variables.at("cohesion") ==
               Approx(jmaterial["cohesion"]).epsilon(Tolerance));
-      REQUIRE(state_variables.at("epsilon") ==
-              Approx(-8907.47728811).epsilon(Tolerance));
-      REQUIRE(state_variables.at("rho") ==
-              Approx(8891.8404917).epsilon(Tolerance));
+      REQUIRE(state_variables.at("pressure") ==
+              Approx(-5142.73441009).epsilon(Tolerance));
+      REQUIRE(state_variables.at("tau") ==
+              Approx(6287.48070891).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") ==
               Approx(0.09473338).epsilon(Tolerance));
       REQUIRE(state_variables.at("pdstrain") == Approx(0.).epsilon(Tolerance));
@@ -1410,9 +1410,9 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi & psi, without softening)",
     REQUIRE(state_variables.at("psi") == Approx(0.26179939).epsilon(Tolerance));
     REQUIRE(state_variables.at("cohesion") ==
             Approx(jmaterial["cohesion"]).epsilon(Tolerance));
-    REQUIRE(state_variables.at("epsilon") ==
-            Approx(-10392.30484541).epsilon(Tolerance));
-    REQUIRE(state_variables.at("rho") == Approx(2000.).epsilon(Tolerance));
+    REQUIRE(state_variables.at("pressure") ==
+            Approx(-6000.).epsilon(Tolerance));
+    REQUIRE(state_variables.at("tau") == Approx(1414.21356237).epsilon(Tolerance));
     REQUIRE(state_variables.at("theta") ==
             Approx(0.13545926).epsilon(Tolerance));
     REQUIRE(state_variables.at("pdstrain") == Approx(0.).epsilon(Tolerance));
@@ -1472,10 +1472,10 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi & psi, without softening)",
               Approx(0.26179939).epsilon(Tolerance));
       REQUIRE(state_variables.at("cohesion") ==
               Approx(jmaterial["cohesion"]).epsilon(Tolerance));
-      REQUIRE(state_variables.at("epsilon") ==
-              Approx(-8948.92917244).epsilon(Tolerance));
-      REQUIRE(state_variables.at("rho") ==
-              Approx(9669.89676021).epsilon(Tolerance));
+      REQUIRE(state_variables.at("pressure") ==
+              Approx(-5166.66666667).epsilon(Tolerance));
+      REQUIRE(state_variables.at("tau") ==
+              Approx(6837.64957252).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") ==
               Approx(0.36378823).epsilon(Tolerance));
       REQUIRE(state_variables.at("pdstrain") == Approx(0.).epsilon(Tolerance));
@@ -1575,10 +1575,10 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi & psi, without softening)",
               Approx(0.26179939).epsilon(Tolerance));
       REQUIRE(state_variables.at("cohesion") ==
               Approx(jmaterial["cohesion"]).epsilon(Tolerance));
-      REQUIRE(state_variables.at("epsilon") ==
-              Approx(4041.45188433).epsilon(Tolerance));
-      REQUIRE(state_variables.at("rho") ==
-              Approx(7670.22471249).epsilon(Tolerance));
+      REQUIRE(state_variables.at("pressure") ==
+              Approx(2333.333333).epsilon(Tolerance));
+      REQUIRE(state_variables.at("tau") ==
+              Approx(5423.66790743).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") ==
               Approx(0.08181078).epsilon(Tolerance));
       REQUIRE(state_variables.at("pdstrain") == Approx(0.).epsilon(Tolerance));
@@ -1717,10 +1717,10 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi & psi, without softening)",
     REQUIRE(state_variables.at("psi") == Approx(0.26179939).epsilon(Tolerance));
     REQUIRE(state_variables.at("cohesion") ==
             Approx(jmaterial["cohesion"]).epsilon(Tolerance));
-    REQUIRE(state_variables.at("epsilon") ==
-            Approx(-10350.85296109).epsilon(Tolerance));
-    REQUIRE(state_variables.at("rho") ==
-            Approx(6436.54117983).epsilon(Tolerance));
+    REQUIRE(state_variables.at("pressure") ==
+            Approx(-5976.06774343).epsilon(Tolerance));
+    REQUIRE(state_variables.at("tau") ==
+            Approx(4551.32191564).epsilon(Tolerance));
     REQUIRE(state_variables.at("theta") ==
             Approx(0.32751078).epsilon(Tolerance));
     REQUIRE(state_variables.at("pdstrain") == Approx(0.).epsilon(Tolerance));
@@ -1780,10 +1780,10 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi & psi, without softening)",
               Approx(0.26179939).epsilon(Tolerance));
       REQUIRE(state_variables.at("cohesion") ==
               Approx(jmaterial["cohesion"]).epsilon(Tolerance));
-      REQUIRE(state_variables.at("epsilon") ==
-              Approx(-8907.47728811).epsilon(Tolerance));
-      REQUIRE(state_variables.at("rho") ==
-              Approx(8891.8404917).epsilon(Tolerance));
+      REQUIRE(state_variables.at("pressure") ==
+              Approx(-5142.73441009).epsilon(Tolerance));
+      REQUIRE(state_variables.at("tau") ==
+              Approx(6287.48070891).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") ==
               Approx(0.09473338).epsilon(Tolerance));
       REQUIRE(state_variables.at("pdstrain") == Approx(0.).epsilon(Tolerance));
@@ -1971,9 +1971,9 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi & psi, with softening)",
               Approx(0.26179939).epsilon(Tolerance));
       REQUIRE(state_variables.at("cohesion") ==
               Approx(jmaterial["cohesion"]).epsilon(Tolerance));
-      REQUIRE(state_variables.at("epsilon") ==
-              Approx(-10392.30484541).epsilon(Tolerance));
-      REQUIRE(state_variables.at("rho") == Approx(2000.).epsilon(Tolerance));
+      REQUIRE(state_variables.at("pressure") ==
+              Approx(-6000.).epsilon(Tolerance));
+      REQUIRE(state_variables.at("tau") == Approx(1414.21356237).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") ==
               Approx(0.13545926).epsilon(Tolerance));
       REQUIRE(state_variables.at("pdstrain") == Approx(0.).epsilon(Tolerance));
@@ -2035,10 +2035,10 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi & psi, with softening)",
               Approx(0.24933524386179).epsilon(Tolerance));
       REQUIRE(state_variables.at("cohesion") ==
               Approx(1952.39047714).epsilon(Tolerance));
-      REQUIRE(state_variables.at("epsilon") ==
-              Approx(-8948.92917244).epsilon(Tolerance));
-      REQUIRE(state_variables.at("rho") ==
-              Approx(9669.89676021).epsilon(Tolerance));
+      REQUIRE(state_variables.at("pressure") ==
+              Approx(-5166.66666667).epsilon(Tolerance));
+      REQUIRE(state_variables.at("tau") ==
+              Approx(6837.64957252).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") ==
               Approx(0.36378823).epsilon(Tolerance));
       REQUIRE(state_variables.at("pdstrain") ==
@@ -2146,9 +2146,9 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi & psi, with softening)",
               Approx(0.26179939).epsilon(Tolerance));
       REQUIRE(state_variables.at("cohesion") ==
               Approx(jmaterial["cohesion"]).epsilon(Tolerance));
-      REQUIRE(state_variables.at("epsilon") ==
-              Approx(-10392.30484541).epsilon(Tolerance));
-      REQUIRE(state_variables.at("rho") == Approx(2000.).epsilon(Tolerance));
+      REQUIRE(state_variables.at("pressure") ==
+              Approx(-6000.).epsilon(Tolerance));
+      REQUIRE(state_variables.at("tau") == Approx(1414.21356237).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") ==
               Approx(0.13545926).epsilon(Tolerance));
       REQUIRE(state_variables.at("pdstrain") == Approx(0.).epsilon(Tolerance));
@@ -2199,10 +2199,10 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi & psi, with softening)",
       // Check if stress invariants is computed correctly based on trial stress
       REQUIRE(mohr_coulomb->compute_stress_invariants(
                   trial_stress, &state_variables) == true);
-      REQUIRE(state_variables.at("epsilon") ==
-              Approx(-8948.92917244).epsilon(Tolerance));
-      REQUIRE(state_variables.at("rho") ==
-              Approx(9669.89676021).epsilon(Tolerance));
+      REQUIRE(state_variables.at("pressure") ==
+              Approx(-5166.66666667).epsilon(Tolerance));
+      REQUIRE(state_variables.at("tau") ==
+              Approx(6837.64957252).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") ==
               Approx(0.36378823).epsilon(Tolerance));
       // Initialise values of yield functions based on trial stress
@@ -2303,10 +2303,10 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi & psi, with softening)",
               Approx(0.26179939).epsilon(Tolerance));
       REQUIRE(state_variables.at("cohesion") ==
               Approx(jmaterial["cohesion"]).epsilon(Tolerance));
-      REQUIRE(state_variables.at("epsilon") ==
-              Approx(-10103.62971082).epsilon(Tolerance));
-      REQUIRE(state_variables.at("rho") ==
-              Approx(1080.12344973).epsilon(Tolerance));
+      REQUIRE(state_variables.at("pressure") ==
+              Approx(-5833.33333333).epsilon(Tolerance));
+      REQUIRE(state_variables.at("tau") ==
+              Approx(763.76261582).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") ==
               Approx(0.33347317).epsilon(Tolerance));
       REQUIRE(state_variables.at("pdstrain") == Approx(0.).epsilon(Tolerance));
@@ -2367,10 +2367,10 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi & psi, with softening)",
       REQUIRE(state_variables.at("psi") == Approx(0.).epsilon(Tolerance));
       REQUIRE(state_variables.at("cohesion") ==
               Approx(1000.).epsilon(Tolerance));
-      REQUIRE(state_variables.at("epsilon") ==
-              Approx(-8660.25403784).epsilon(Tolerance));
-      REQUIRE(state_variables.at("rho") ==
-              Approx(11008.46903673).epsilon(Tolerance));
+      REQUIRE(state_variables.at("pressure") ==
+              Approx(-5000.).epsilon(Tolerance));
+      REQUIRE(state_variables.at("tau") ==
+              Approx(7784.16310635).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") ==
               Approx(0.42072067).epsilon(Tolerance));
       REQUIRE(state_variables.at("pdstrain") ==
@@ -2526,10 +2526,10 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi & psi, with softening)",
               Approx(0.26179939).epsilon(Tolerance));
       REQUIRE(state_variables.at("cohesion") ==
               Approx(jmaterial["cohesion"]).epsilon(Tolerance));
-      REQUIRE(state_variables.at("epsilon") ==
-              Approx(-10392.30484541).epsilon(Tolerance));
-      REQUIRE(state_variables.at("rho") ==
-              Approx(6087.30146452).epsilon(Tolerance));
+      REQUIRE(state_variables.at("pressure") ==
+              Approx(-6000.).epsilon(Tolerance));
+      REQUIRE(state_variables.at("tau") ==
+              Approx(4304.37214469).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") ==
               Approx(0.32101934).epsilon(Tolerance));
       REQUIRE(state_variables.at("pdstrain") == Approx(0.).epsilon(Tolerance));
@@ -2591,10 +2591,10 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi & psi, with softening)",
               Approx(0.23793236923794).epsilon(Tolerance));
       REQUIRE(state_variables.at("cohesion") ==
               Approx(1908.83470445882).epsilon(Tolerance));
-      REQUIRE(state_variables.at("epsilon") ==
-              Approx(-10392.30484541).epsilon(Tolerance));
-      REQUIRE(state_variables.at("rho") ==
-              Approx(8257.6195444).epsilon(Tolerance));
+      REQUIRE(state_variables.at("pressure") ==
+              Approx(6000.).epsilon(Tolerance));
+      REQUIRE(state_variables.at("tau") ==
+              Approx(5839.01877630).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") ==
               Approx(0.3747326).epsilon(Tolerance));
       REQUIRE(state_variables.at("pdstrain") ==
@@ -2702,10 +2702,10 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi & psi, with softening)",
               Approx(0.26179939).epsilon(Tolerance));
       REQUIRE(state_variables.at("cohesion") ==
               Approx(jmaterial["cohesion"]).epsilon(Tolerance));
-      REQUIRE(state_variables.at("epsilon") ==
-              Approx(-9439.90784136).epsilon(Tolerance));
-      REQUIRE(state_variables.at("rho") ==
-              Approx(6108.85587542).epsilon(Tolerance));
+      REQUIRE(state_variables.at("pressure") ==
+              Approx(-5450.13333333).epsilon(Tolerance));
+      REQUIRE(state_variables.at("tau") ==
+              Approx(4319.61341480).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") ==
               Approx(0.37419232).epsilon(Tolerance));
       REQUIRE(state_variables.at("pdstrain") == Approx(0.).epsilon(Tolerance));
@@ -2756,10 +2756,10 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi & psi, with softening)",
       // Check if stress invariants is computed correctly based on trial stress
       REQUIRE(mohr_coulomb->compute_stress_invariants(
                   trial_stress, &state_variables) == true);
-      REQUIRE(state_variables.at("epsilon") ==
-              Approx(-7996.53216838).epsilon(Tolerance));
-      REQUIRE(state_variables.at("rho") ==
-              Approx(7665.51627945).epsilon(Tolerance));
+      REQUIRE(state_variables.at("pressure") ==
+              Approx(-4616.80000000).epsilon(Tolerance));
+      REQUIRE(state_variables.at("tau") ==
+              Approx(5420.33854249).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") ==
               Approx(0.20272541).epsilon(Tolerance));
       // Initialise values of yield functions based on trial stress
@@ -2860,10 +2860,10 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi & psi, with softening)",
               Approx(0.26179939).epsilon(Tolerance));
       REQUIRE(state_variables.at("cohesion") ==
               Approx(jmaterial["cohesion"]).epsilon(Tolerance));
-      REQUIRE(state_variables.at("epsilon") ==
-              Approx(-10392.30484541).epsilon(Tolerance));
-      REQUIRE(state_variables.at("rho") ==
-              Approx(1414.21356237).epsilon(Tolerance));
+      REQUIRE(state_variables.at("pressure") ==
+              Approx(-6000.).epsilon(Tolerance));
+      REQUIRE(state_variables.at("tau") ==
+              Approx(1000.).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") ==
               Approx(0.52359878).epsilon(Tolerance));
       REQUIRE(state_variables.at("pdstrain") == Approx(0.).epsilon(Tolerance));
@@ -2924,10 +2924,10 @@ TEST_CASE("MohrCoulomb is checked in 2D (c & phi & psi, with softening)",
       REQUIRE(state_variables.at("psi") == Approx(0.).epsilon(Tolerance));
       REQUIRE(state_variables.at("cohesion") ==
               Approx(1000.).epsilon(Tolerance));
-      REQUIRE(state_variables.at("epsilon") ==
-              Approx(-8948.92917244).epsilon(Tolerance));
-      REQUIRE(state_variables.at("rho") ==
-              Approx(11057.85395646).epsilon(Tolerance));
+      REQUIRE(state_variables.at("pressure") ==
+              Approx(-5166.66666667).epsilon(Tolerance));
+      REQUIRE(state_variables.at("tau") ==
+              Approx(7819.08351798).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") ==
               Approx(0.38398831).epsilon(Tolerance));
       REQUIRE(state_variables.at("pdstrain") ==
@@ -3120,10 +3120,10 @@ TEST_CASE("MohrCoulomb is checked in 3D (c & phi & psi, with softening)",
               Approx(0.26179939).epsilon(Tolerance));
       REQUIRE(state_variables.at("cohesion") ==
               Approx(jmaterial["cohesion"]).epsilon(Tolerance));
-      REQUIRE(state_variables.at("epsilon") ==
-              Approx(-10392.30484541).epsilon(Tolerance));
-      REQUIRE(state_variables.at("rho") ==
-              Approx(5477.22557505).epsilon(Tolerance));
+      REQUIRE(state_variables.at("pressure") ==
+              Approx(-6000.).epsilon(Tolerance));
+      REQUIRE(state_variables.at("tau") ==
+              Approx(3872.98334621).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") ==
               Approx(0.76870359).epsilon(Tolerance));
       REQUIRE(state_variables.at("pdstrain") == Approx(0.).epsilon(Tolerance));
@@ -3188,10 +3188,10 @@ TEST_CASE("MohrCoulomb is checked in 3D (c & phi & psi, with softening)",
               Approx(0.2379483284631).epsilon(Tolerance));
       REQUIRE(state_variables.at("cohesion") ==
               Approx(1908.89566421).epsilon(Tolerance));
-      REQUIRE(state_variables.at("epsilon") ==
-              Approx(-8948.92917244).epsilon(Tolerance));
-      REQUIRE(state_variables.at("rho") ==
-              Approx(15190.44130048).epsilon(Tolerance));
+      REQUIRE(state_variables.at("pressure") ==
+              Approx(-5166.66666667).epsilon(Tolerance));
+      REQUIRE(state_variables.at("tau") ==
+              Approx(10741.26405279).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") ==
               Approx(0.33392734).epsilon(Tolerance));
       REQUIRE(state_variables.at("pdstrain") ==
@@ -3306,10 +3306,10 @@ TEST_CASE("MohrCoulomb is checked in 3D (c & phi & psi, with softening)",
               Approx(0.26179939).epsilon(Tolerance));
       REQUIRE(state_variables.at("cohesion") ==
               Approx(jmaterial["cohesion"]).epsilon(Tolerance));
-      REQUIRE(state_variables.at("epsilon") ==
-              Approx(-10392.30484541).epsilon(Tolerance));
-      REQUIRE(state_variables.at("rho") ==
-              Approx(5477.22557505).epsilon(Tolerance));
+      REQUIRE(state_variables.at("pressure") ==
+              Approx(-6000.).epsilon(Tolerance));
+      REQUIRE(state_variables.at("tau") ==
+              Approx(3872.98334621).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") ==
               Approx(0.76870359).epsilon(Tolerance));
       REQUIRE(state_variables.at("pdstrain") == Approx(0.).epsilon(Tolerance));
@@ -3362,10 +3362,10 @@ TEST_CASE("MohrCoulomb is checked in 3D (c & phi & psi, with softening)",
       // Check if stress invariants is computed correctly based on trial stress
       REQUIRE(mohr_coulomb->compute_stress_invariants(
                   trial_stress, &state_variables) == true);
-      REQUIRE(state_variables.at("epsilon") ==
-              Approx(-8948.92917244).epsilon(Tolerance));
-      REQUIRE(state_variables.at("rho") ==
-              Approx(15190.44130048).epsilon(Tolerance));
+      REQUIRE(state_variables.at("pressure") ==
+              Approx(-5166.66666667).epsilon(Tolerance));
+      REQUIRE(state_variables.at("tau") ==
+              Approx(10741.26405279).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") ==
               Approx(0.33392734).epsilon(Tolerance));
       // Initialise values of yield functions based on trial stress
@@ -3472,10 +3472,10 @@ TEST_CASE("MohrCoulomb is checked in 3D (c & phi & psi, with softening)",
               Approx(0.26179939).epsilon(Tolerance));
       REQUIRE(state_variables.at("cohesion") ==
               Approx(jmaterial["cohesion"]).epsilon(Tolerance));
-      REQUIRE(state_variables.at("epsilon") ==
-              Approx(-9814.95457622).epsilon(Tolerance));
-      REQUIRE(state_variables.at("rho") ==
-              Approx(972.96796796).epsilon(Tolerance));
+      REQUIRE(state_variables.at("pressure") ==
+              Approx(-5666.666666667).epsilon(Tolerance));
+      REQUIRE(state_variables.at("tau") ==
+              Approx(687.99224802).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") ==
               Approx(0.33010649).epsilon(Tolerance));
       REQUIRE(state_variables.at("pdstrain") == Approx(0.).epsilon(Tolerance));
@@ -3539,10 +3539,10 @@ TEST_CASE("MohrCoulomb is checked in 3D (c & phi & psi, with softening)",
       REQUIRE(state_variables.at("psi") == Approx(0.).epsilon(Tolerance));
       REQUIRE(state_variables.at("cohesion") ==
               Approx(1000.).epsilon(Tolerance));
-      REQUIRE(state_variables.at("epsilon") ==
-              Approx(-8371.57890325).epsilon(Tolerance));
-      REQUIRE(state_variables.at("rho") ==
-              Approx(19875.34922720).epsilon(Tolerance));
+      REQUIRE(state_variables.at("pressure") ==
+              Approx(-4833.33333333).epsilon(Tolerance));
+      REQUIRE(state_variables.at("tau") ==
+              Approx(14053.99421700).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") ==
               Approx(0.30645028).epsilon(Tolerance));
       REQUIRE(state_variables.at("pdstrain") ==
@@ -3703,10 +3703,10 @@ TEST_CASE("MohrCoulomb is checked in 3D (c & phi & psi, with softening)",
               Approx(0.26179939).epsilon(Tolerance));
       REQUIRE(state_variables.at("cohesion") ==
               Approx(jmaterial["cohesion"]).epsilon(Tolerance));
-      REQUIRE(state_variables.at("epsilon") ==
-              Approx(-9814.95457622).epsilon(Tolerance));
-      REQUIRE(state_variables.at("rho") ==
-              Approx(6137.6353074).epsilon(Tolerance));
+      REQUIRE(state_variables.at("pressure") ==
+              Approx(-5666.666666667).epsilon(Tolerance));
+      REQUIRE(state_variables.at("tau") ==
+              Approx(4339.96354631).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") ==
               Approx(0.62535818).epsilon(Tolerance));
       REQUIRE(state_variables.at("pdstrain") == Approx(0.).epsilon(Tolerance));
@@ -3771,10 +3771,10 @@ TEST_CASE("MohrCoulomb is checked in 3D (c & phi & psi, with softening)",
               Approx(0.23044412153714).epsilon(Tolerance));
       REQUIRE(state_variables.at("cohesion") ==
               Approx(1880.23170517852).epsilon(Tolerance));
-      REQUIRE(state_variables.at("epsilon") ==
-              Approx(-9814.95457622).epsilon(Tolerance));
-      REQUIRE(state_variables.at("rho") ==
-              Approx(7818.56228978).epsilon(Tolerance));
+      REQUIRE(state_variables.at("pressure") ==
+              Approx(-5666.666666667).epsilon(Tolerance));
+      REQUIRE(state_variables.at("tau") ==
+              Approx(5528.55841423).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") ==
               Approx(0.46506728).epsilon(Tolerance));
       REQUIRE(state_variables.at("pdstrain") ==
@@ -3891,10 +3891,10 @@ TEST_CASE("MohrCoulomb is checked in 3D (c & phi & psi, with softening)",
               Approx(0.26179939).epsilon(Tolerance));
       REQUIRE(state_variables.at("cohesion") ==
               Approx(jmaterial["cohesion"]).epsilon(Tolerance));
-      REQUIRE(state_variables.at("epsilon") ==
-              Approx(-9406.76793591).epsilon(Tolerance));
-      REQUIRE(state_variables.at("rho") ==
-              Approx(6152.44390466).epsilon(Tolerance));
+      REQUIRE(state_variables.at("pressure") ==
+              Approx(-5431.).epsilon(Tolerance));
+      REQUIRE(state_variables.at("tau") ==
+              Approx(4350.43480585).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") ==
               Approx(0.43146734).epsilon(Tolerance));
       REQUIRE(state_variables.at("pdstrain") == Approx(0.).epsilon(Tolerance));
@@ -3947,10 +3947,10 @@ TEST_CASE("MohrCoulomb is checked in 3D (c & phi & psi, with softening)",
       // Check if stress invariants is computed correctly based on trial stress
       REQUIRE(mohr_coulomb->compute_stress_invariants(
                   trial_stress, &state_variables) == true);
-      REQUIRE(state_variables.at("epsilon") ==
-              Approx(-7963.39226293).epsilon(Tolerance));
-      REQUIRE(state_variables.at("rho") ==
-              Approx(7963.60445905).epsilon(Tolerance));
+      REQUIRE(state_variables.at("pressure") ==
+              Approx(-4597.66666667).epsilon(Tolerance));
+      REQUIRE(state_variables.at("tau") ==
+              Approx(5631.11871568).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") ==
               Approx(0.16536572).epsilon(Tolerance));
       // Initialise values of yield functions based on trial stress
@@ -4057,10 +4057,10 @@ TEST_CASE("MohrCoulomb is checked in 3D (c & phi & psi, with softening)",
               Approx(0.26179939).epsilon(Tolerance));
       REQUIRE(state_variables.at("cohesion") ==
               Approx(jmaterial["cohesion"]).epsilon(Tolerance));
-      REQUIRE(state_variables.at("epsilon") ==
-              Approx(-10307.43435584).epsilon(Tolerance));
-      REQUIRE(state_variables.at("rho") ==
-              Approx(1414.35709777).epsilon(Tolerance));
+      REQUIRE(state_variables.at("pressure") ==
+              Approx(-5951.).epsilon(Tolerance));
+      REQUIRE(state_variables.at("tau") ==
+              Approx(1000.10149485).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") ==
               Approx(0.51890420).epsilon(Tolerance));
       REQUIRE(state_variables.at("pdstrain") == Approx(0.).epsilon(Tolerance));
@@ -4124,10 +4124,10 @@ TEST_CASE("MohrCoulomb is checked in 3D (c & phi & psi, with softening)",
       REQUIRE(state_variables.at("psi") == Approx(0.).epsilon(Tolerance));
       REQUIRE(state_variables.at("cohesion") ==
               Approx(1000.).epsilon(Tolerance));
-      REQUIRE(state_variables.at("epsilon") ==
-              Approx(-8864.05868287).epsilon(Tolerance));
-      REQUIRE(state_variables.at("rho") ==
-              Approx(2417.87632461).epsilon(Tolerance));
+      REQUIRE(state_variables.at("pressure") ==
+              Approx(-5117.66666667).epsilon(Tolerance)); // Check * sqrt(3)
+      REQUIRE(state_variables.at("tau") ==
+              Approx(1709.69674520).epsilon(Tolerance));
       REQUIRE(state_variables.at("theta") ==
               Approx(0.41113704).epsilon(Tolerance));
       REQUIRE(state_variables.at("pdstrain") ==

--- a/tests/particles/particle_test.cc
+++ b/tests/particles/particle_test.cc
@@ -1458,8 +1458,8 @@ TEST_CASE("Particle is checked for 2D case", "[particle][2D]") {
                 Approx(jmaterial["dilation"]).epsilon(Tolerance));
         REQUIRE(state_variables.at("cohesion") ==
                 Approx(jmaterial["cohesion"]).epsilon(Tolerance));
-        REQUIRE(state_variables.at("epsilon") == Approx(0.).epsilon(Tolerance));
-        REQUIRE(state_variables.at("rho") == Approx(0.).epsilon(Tolerance));
+        REQUIRE(state_variables.at("pressure") == Approx(0.).epsilon(Tolerance));
+        REQUIRE(state_variables.at("tau") == Approx(0.).epsilon(Tolerance));
         REQUIRE(state_variables.at("theta") == Approx(0.).epsilon(Tolerance));
         REQUIRE(state_variables.at("pdstrain") ==
                 Approx(0.).epsilon(Tolerance));
@@ -2991,8 +2991,8 @@ TEST_CASE("Particle is checked for 3D case", "[particle][3D]") {
                 Approx(jmaterial["dilation"]).epsilon(Tolerance));
         REQUIRE(state_variables.at("cohesion") ==
                 Approx(jmaterial["cohesion"]).epsilon(Tolerance));
-        REQUIRE(state_variables.at("epsilon") == Approx(0.).epsilon(Tolerance));
-        REQUIRE(state_variables.at("rho") == Approx(0.).epsilon(Tolerance));
+        REQUIRE(state_variables.at("pressure") == Approx(0.).epsilon(Tolerance));
+        REQUIRE(state_variables.at("tau") == Approx(0.).epsilon(Tolerance));
         REQUIRE(state_variables.at("theta") == Approx(0.).epsilon(Tolerance));
         REQUIRE(state_variables.at("pdstrain") ==
                 Approx(0.).epsilon(Tolerance));

--- a/tests/particles/particle_twophase_test.cc
+++ b/tests/particles/particle_twophase_test.cc
@@ -1349,8 +1349,8 @@ TEST_CASE("TwoPhase Particle is checked for 2D case",
                 Approx(jmaterial["dilation"]).epsilon(Tolerance));
         REQUIRE(state_variables.at("cohesion") ==
                 Approx(jmaterial["cohesion"]).epsilon(Tolerance));
-        REQUIRE(state_variables.at("epsilon") == Approx(0.).epsilon(Tolerance));
-        REQUIRE(state_variables.at("rho") == Approx(0.).epsilon(Tolerance));
+        REQUIRE(state_variables.at("pressure") == Approx(0.).epsilon(Tolerance));
+        REQUIRE(state_variables.at("tau") == Approx(0.).epsilon(Tolerance));
         REQUIRE(state_variables.at("theta") == Approx(0.).epsilon(Tolerance));
         REQUIRE(state_variables.at("pdstrain") ==
                 Approx(0.).epsilon(Tolerance));
@@ -2873,8 +2873,8 @@ TEST_CASE("TwoPhase Particle is checked for 3D case",
                 Approx(jmaterial["dilation"]).epsilon(Tolerance));
         REQUIRE(state_variables.at("cohesion") ==
                 Approx(jmaterial["cohesion"]).epsilon(Tolerance));
-        REQUIRE(state_variables.at("epsilon") == Approx(0.).epsilon(Tolerance));
-        REQUIRE(state_variables.at("rho") == Approx(0.).epsilon(Tolerance));
+        REQUIRE(state_variables.at("pressure") == Approx(0.).epsilon(Tolerance));
+        REQUIRE(state_variables.at("tau") == Approx(0.).epsilon(Tolerance));
         REQUIRE(state_variables.at("theta") == Approx(0.).epsilon(Tolerance));
         REQUIRE(state_variables.at("pdstrain") ==
                 Approx(0.).epsilon(Tolerance));


### PR DESCRIPTION
## Summary
This PR extracts only the theory-critical changes in Mohr-Coulomb stress integration.

## Changes
- Fix yield admissibility tolerance in `compute_yield_state` (`1e-7`)
- Refactor `compute_stress` into:
  - elastic predictor
  - single-surface return
  - corner return (multi-surface)
- Add dedicated helpers:
  - `compute_single_surface_return`
  - `compute_corner_return`
  - `update_softening_parameters`
