### PR TITLE
[Clang-format] Update clang-format in continuous integrator to use a more recent version (v 18.1.8)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,8 +78,8 @@ jobs:
       - run:
           name: clang-format
           command: |
-            clang-format --version
-            python3 ./clang-tools/run-clang-format.py -r include/* src/* tests/*
+            pip3 install clang-format==18.1.3
+            python3 ./clang-tools/run-clang-format.py --clang-format-executable ~/.local/bin/clang-format -r include/* src/* tests/*
 
   codecov_unit:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,7 @@ jobs:
       - run:
           name: clang-format
           command: |
+            clang-format --version
             python3 ./clang-tools/run-clang-format.py -r include/* src/* tests/*
 
   codecov_unit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
       - run:
           name: clang-format
           command: |
-            pip3 install clang-format==18.1.3
+            pip3 install --user clang-format==18.1.3
             python3 ./clang-tools/run-clang-format.py --clang-format-executable ~/.local/bin/clang-format -r include/* src/* tests/*
 
   codecov_unit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,8 +78,9 @@ jobs:
       - run:
           name: clang-format
           command: |
-            pip3 install --user clang-format==18.1.3
-            python3 ./clang-tools/run-clang-format.py --clang-format-executable ~/.local/bin/clang-format -r include/* src/* tests/*
+            pip3 install --user clang-format==18.1.8
+            export PATH=$HOME/.local/bin:$PATH
+            python3 ./clang-tools/run-clang-format.py --clang-format-executable clang-format -r include/* src/* tests/*
 
   codecov_unit:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
           name: clang-format
           command: |
             pip3 install --user clang-format==18.1.3
-            python3 ./clang-tools/run-clang-format.py --clang-format-executable ~/.local/bin/clang-format -r include/* src/* tests/*
+            python3 ./clang-tools/run-clang-format.py --clang-format-executable ~/.local/bin/clang-format-18 -r include/* src/* tests/*
 
   codecov_unit:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
           name: clang-format
           command: |
             pip3 install --user clang-format==18.1.3
-            python3 ./clang-tools/run-clang-format.py --clang-format-executable ~/.local/bin/clang-format-18 -r include/* src/* tests/*
+            python3 ./clang-tools/run-clang-format.py --clang-format-executable ~/.local/bin/clang-format -r include/* src/* tests/*
 
   codecov_unit:
     docker:

--- a/.clang-format
+++ b/.clang-format
@@ -2,7 +2,7 @@
 # BasedOnStyle:  CUED GeoMechanics
 AccessModifierOffset: -1
 ConstructorInitializerIndentWidth: 4
-AlignEscapedNewlinesLeft: true
+AlignEscapedNewlines: Left
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortIfStatementsOnASingleLine: true
@@ -13,9 +13,9 @@ BreakBeforeBinaryOperators: false
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
 BinPackParameters: true
-ColumnLimit:     80
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
-DerivePointerBinding: false
+ColumnLimit: 80
+PackConstructorInitializers: CurrentLine
+DerivePointerAlignment: false
 ExperimentalAutoDetectBinPacking: false
 IndentCaseLabels: true
 MaxEmptyLinesToKeep: 1
@@ -27,20 +27,20 @@ PenaltyBreakString: 1000
 PenaltyBreakFirstLessLess: 120
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
-PointerBindsToType: true
+PointerAlignment: Left
 SpacesBeforeTrailingComments: 2
 Cpp11BracedListStyle: true
-Standard:        Auto
-IndentWidth:     2
-TabWidth:        8
-UseTab:          Never
+Standard: Auto
+IndentWidth: 2
+TabWidth: 8
+UseTab: Never
 BreakBeforeBraces: Attach
-IndentFunctionDeclarationAfterType: true
+IndentWrappedFunctionNames: true
 SpacesInParentheses: false
-SpacesInAngles:  false
+SpacesInAngles: false
 SpaceInEmptyParentheses: false
 SpacesInCStyleCastParentheses: false
-SpaceAfterControlStatementKeyword: true
+SpaceBeforeParens: ControlStatements
 SpaceBeforeAssignmentOperators: true
 ContinuationIndentWidth: 4
 ...

--- a/include/cells/cell.tcc
+++ b/include/cells/cell.tcc
@@ -3,7 +3,9 @@ template <unsigned Tdim>
 mpm::Cell<Tdim>::Cell(Index id, unsigned nnodes,
                       const std::shared_ptr<Element<Tdim>>& elementptr,
                       bool isoparametric)
-    : id_{id}, nnodes_{nnodes}, isoparametric_{isoparametric} {
+    : id_{id},
+      nnodes_{nnodes},
+      isoparametric_{isoparametric} {
   // Check if the dimension is between 1 & 3
   static_assert((Tdim >= 1 && Tdim <= 3), "Invalid global dimension");
 

--- a/include/contacts/contact.h
+++ b/include/contacts/contact.h
@@ -15,10 +15,10 @@ class Contact {
   Contact(const std::shared_ptr<mpm::Mesh<Tdim>>& mesh);
 
   //! Intialize
-  virtual inline void initialise(){};
+  virtual inline void initialise() {};
 
   //! Compute contact forces
-  virtual inline void compute_contact_forces(){};
+  virtual inline void compute_contact_forces() {};
 
  protected:
   //! Mesh object

--- a/include/linear_solvers/linear_solvers/direct_eigen.h
+++ b/include/linear_solvers/linear_solvers/direct_eigen.h
@@ -27,7 +27,7 @@ class DirectEigen : public SolverBase<Traits> {
   };
 
   //! Destructor
-  ~DirectEigen(){};
+  ~DirectEigen() {};
 
   //! Matrix solver
   Eigen::VectorXd solve(const Eigen::SparseMatrix<double>& A,

--- a/include/linear_solvers/linear_solvers/iterative_eigen.h
+++ b/include/linear_solvers/linear_solvers/iterative_eigen.h
@@ -29,7 +29,7 @@ class IterativeEigen : public SolverBase<Traits> {
   };
 
   //! Destructor
-  ~IterativeEigen(){};
+  ~IterativeEigen() {};
 
   //! Matrix solver with default initial guess
   Eigen::VectorXd solve(const Eigen::SparseMatrix<double>& A,

--- a/include/linear_solvers/linear_solvers/solver_base.h
+++ b/include/linear_solvers/linear_solvers/solver_base.h
@@ -21,7 +21,7 @@ class SolverBase {
   };
 
   //! Destructor
-  virtual ~SolverBase(){};
+  virtual ~SolverBase() {};
 
   //! Matrix solver with default initial guess
   virtual Eigen::VectorXd solve(const Eigen::SparseMatrix<double>& A,

--- a/include/loads_bcs/displacement_constraint.h
+++ b/include/loads_bcs/displacement_constraint.h
@@ -14,7 +14,9 @@ class DisplacementConstraint {
   //! \param[in] dir Direction of displacement constraint load
   //! \param[in] velocity Constraint displacement
   DisplacementConstraint(int setid, unsigned dir, double displacement)
-      : setid_{setid}, dir_{dir}, displacement_{displacement} {};
+      : setid_{setid},
+        dir_{dir},
+        displacement_{displacement} {};
 
   // Set id
   int setid() const { return setid_; }

--- a/include/loads_bcs/friction_constraint.h
+++ b/include/loads_bcs/friction_constraint.h
@@ -14,7 +14,10 @@ class FrictionConstraint {
   //! \param[in] sign_n Sign of normal direction
   //! \param[in] friction Constraint  friction
   FrictionConstraint(int setid, unsigned dir, int sign_n, double friction)
-      : setid_{setid}, dir_{dir}, sign_n_{sign_n}, friction_{friction} {};
+      : setid_{setid},
+        dir_{dir},
+        sign_n_{sign_n},
+        friction_{friction} {};
 
   // Set id
   int setid() const { return setid_; }

--- a/include/loads_bcs/pressure_constraint.h
+++ b/include/loads_bcs/pressure_constraint.h
@@ -12,7 +12,9 @@ class PressureConstraint {
   //! \param[in] setid  set id
   //! \param[in] pressure Constraint pressure
   PressureConstraint(int setid, unsigned phase, double pressure)
-      : setid_{setid}, phase_{phase}, pressure_{pressure} {};
+      : setid_{setid},
+        phase_{phase},
+        pressure_{pressure} {};
 
   // Set id
   int setid() const { return setid_; }

--- a/include/loads_bcs/velocity_constraint.h
+++ b/include/loads_bcs/velocity_constraint.h
@@ -13,7 +13,9 @@ class VelocityConstraint {
   //! \param[in] dir Direction of constraint load
   //! \param[in] velocity Constraint  velocity
   VelocityConstraint(int setid, unsigned dir, double velocity)
-      : setid_{setid}, dir_{dir}, velocity_{velocity} {};
+      : setid_{setid},
+        dir_{dir},
+        velocity_{velocity} {};
 
   // Set id
   int setid() const { return setid_; }

--- a/include/materials/finite_strain/hencky_hyper_elastic.h
+++ b/include/materials/finite_strain/hencky_hyper_elastic.h
@@ -27,7 +27,7 @@ class HenckyHyperElastic : public Material<Tdim> {
   HenckyHyperElastic(unsigned id, const Json& material_properties);
 
   //! Destructor
-  ~HenckyHyperElastic() override{};
+  ~HenckyHyperElastic() override {};
 
   //! Delete copy constructor
   HenckyHyperElastic(const HenckyHyperElastic&) = delete;

--- a/include/materials/infinitesimal_strain/bingham_viscoplastic.h
+++ b/include/materials/infinitesimal_strain/bingham_viscoplastic.h
@@ -34,7 +34,7 @@ class BinghamViscoPlastic : public InfinitesimalElastoPlastic<Tdim> {
   BinghamViscoPlastic(unsigned id, const Json& material_properties);
 
   //! Destructor
-  ~BinghamViscoPlastic() override{};
+  ~BinghamViscoPlastic() override {};
 
   //! Delete copy constructor
   BinghamViscoPlastic(const BinghamViscoPlastic&) = delete;

--- a/include/materials/infinitesimal_strain/infinitesimal_elasto_plastic.h
+++ b/include/materials/infinitesimal_strain/infinitesimal_elasto_plastic.h
@@ -32,10 +32,10 @@ class InfinitesimalElastoPlastic : public LinearElastic<Tdim> {
   //! Constructor with id and material properties
   //! \param[in] material_properties Material properties
   InfinitesimalElastoPlastic(unsigned id, const Json& material_properties)
-      : LinearElastic<Tdim>(id, material_properties){};
+      : LinearElastic<Tdim>(id, material_properties) {};
 
   //! Destructor
-  ~InfinitesimalElastoPlastic() override{};
+  ~InfinitesimalElastoPlastic() override {};
 
   //! Delete copy constructor
   InfinitesimalElastoPlastic(const InfinitesimalElastoPlastic&) = delete;

--- a/include/materials/infinitesimal_strain/linear_elastic.h
+++ b/include/materials/infinitesimal_strain/linear_elastic.h
@@ -27,7 +27,7 @@ class LinearElastic : public Material<Tdim> {
   LinearElastic(unsigned id, const Json& material_properties);
 
   //! Destructor
-  ~LinearElastic() override{};
+  ~LinearElastic() override {};
 
   //! Delete copy constructor
   LinearElastic(const LinearElastic&) = delete;

--- a/include/materials/infinitesimal_strain/modified_cam_clay.h
+++ b/include/materials/infinitesimal_strain/modified_cam_clay.h
@@ -32,7 +32,7 @@ class ModifiedCamClay : public InfinitesimalElastoPlastic<Tdim> {
   ModifiedCamClay(unsigned id, const Json& material_properties);
 
   //! Destructor
-  ~ModifiedCamClay() override{};
+  ~ModifiedCamClay() override {};
 
   //! Delete copy constructor
   ModifiedCamClay(const ModifiedCamClay&) = delete;

--- a/include/materials/infinitesimal_strain/mohr_coulomb.h
+++ b/include/materials/infinitesimal_strain/mohr_coulomb.h
@@ -33,7 +33,7 @@ class MohrCoulomb : public InfinitesimalElastoPlastic<Tdim> {
   MohrCoulomb(unsigned id, const Json& material_properties);
 
   //! Destructor
-  ~MohrCoulomb() override{};
+  ~MohrCoulomb() override {};
 
   //! Delete copy constructor
   MohrCoulomb(const MohrCoulomb&) = delete;

--- a/include/materials/material.h
+++ b/include/materials/material.h
@@ -50,7 +50,7 @@ class Material {
   }
 
   //! Destructor
-  virtual ~Material(){};
+  virtual ~Material() {};
 
   //! Delete copy constructor
   Material(const Material&) = delete;
@@ -78,7 +78,7 @@ class Material {
   //! \brief Function that initialise material to be called at the beginning of
   //! time step
   //! \param[in] state_vars History-dependent state variables
-  virtual void initialise(mpm::dense_map* state_vars){};
+  virtual void initialise(mpm::dense_map* state_vars) {};
 
   /**
    * \defgroup InfinitesimalStrain Functions for infinitesimal strain

--- a/include/materials/strain_rate/bingham.h
+++ b/include/materials/strain_rate/bingham.h
@@ -27,7 +27,7 @@ class Bingham : public Material<Tdim> {
   Bingham(unsigned id, const Json& material_properties);
 
   //! Destructor
-  ~Bingham() override{};
+  ~Bingham() override {};
 
   //! Delete copy constructor
   Bingham(const Bingham&) = delete;

--- a/include/materials/strain_rate/newtonian.h
+++ b/include/materials/strain_rate/newtonian.h
@@ -27,7 +27,7 @@ class Newtonian : public Material<Tdim> {
   Newtonian(unsigned id, const Json& material_properties);
 
   //! Destructor
-  ~Newtonian() override{};
+  ~Newtonian() override {};
 
   //! Delete copy constructor
   Newtonian(const Newtonian&) = delete;

--- a/include/mesh/mesh.tcc
+++ b/include/mesh/mesh.tcc
@@ -1,7 +1,8 @@
 // Constructor with id
 template <unsigned Tdim>
 mpm::Mesh<Tdim>::Mesh(unsigned id, bool isoparametric)
-    : id_{id}, isoparametric_{isoparametric} {
+    : id_{id},
+      isoparametric_{isoparametric} {
   // Check if the dimension is between 1 & 3
   static_assert((Tdim >= 1 && Tdim <= 3), "Invalid global dimension");
   //! Logger

--- a/include/nodes/node.h
+++ b/include/nodes/node.h
@@ -26,7 +26,7 @@ class Node : public NodeBase<Tdim> {
   Node(Index id, const VectorDim& coord);
 
   //! Virtual destructor
-  ~Node() override{};
+  ~Node() override {};
 
   //! Delete copy constructor
   Node(const Node<Tdim, Tdof, Tnphases>&) = delete;

--- a/include/nodes/node_base.h
+++ b/include/nodes/node_base.h
@@ -39,10 +39,10 @@ class NodeBase {
   // Constructor with id and coordinates
   //! \param[in] id assign as the id_ of the node
   //! \param[in] coords coordinates of the node
-  NodeBase(mpm::Index id, const VectorDim& coords){};
+  NodeBase(mpm::Index id, const VectorDim& coords) {};
 
   //! Destructor
-  virtual ~NodeBase(){};
+  virtual ~NodeBase() {};
 
   //! Delete copy constructor
   NodeBase(const NodeBase<Tdim>&) = delete;

--- a/include/particles/anti_locking/particle_bbar.h
+++ b/include/particles/anti_locking/particle_bbar.h
@@ -34,7 +34,7 @@ class ParticleBbar : public mpm::Particle<Tdim> {
   ParticleBbar(Index id, const VectorDim& coord, bool status);
 
   //! Destructor
-  ~ParticleBbar() override{};
+  ~ParticleBbar() override {};
 
   //! Delete copy constructor
   ParticleBbar(const ParticleBbar<Tdim>&) = delete;

--- a/include/particles/particle.h
+++ b/include/particles/particle.h
@@ -39,7 +39,7 @@ class Particle : public ParticleBase<Tdim> {
   Particle(Index id, const VectorDim& coord, bool status);
 
   //! Destructor
-  ~Particle() override{};
+  ~Particle() override {};
 
   //! Delete copy constructor
   Particle(const Particle<Tdim>&) = delete;

--- a/include/particles/particle_base.h
+++ b/include/particles/particle_base.h
@@ -60,7 +60,7 @@ class ParticleBase {
   ParticleBase(Index id, const VectorDim& coord, bool status);
 
   //! Destructor
-  virtual ~ParticleBase(){};
+  virtual ~ParticleBase() {};
 
   //! Delete copy constructor
   ParticleBase(const ParticleBase<Tdim>&) = delete;

--- a/include/particles/particle_finite_strain.h
+++ b/include/particles/particle_finite_strain.h
@@ -37,7 +37,7 @@ class ParticleFiniteStrain : public mpm::Particle<Tdim> {
   ParticleFiniteStrain(Index id, const VectorDim& coord, bool status);
 
   //! Destructor
-  ~ParticleFiniteStrain() override{};
+  ~ParticleFiniteStrain() override {};
 
   //! Delete copy constructor
   ParticleFiniteStrain(const ParticleFiniteStrain<Tdim>&) = delete;
@@ -60,7 +60,7 @@ class ParticleFiniteStrain : public mpm::Particle<Tdim> {
   //! Update volume based on deformation gradient increment
   //! Note: Volume is updated in compute_strain() and
   //! compute_strain_volume_newmark() for particle with finite strain
-  void update_volume() noexcept override{};
+  void update_volume() noexcept override {};
 
   //! Compute deformation gradient increment using nodal velocity
   //! \param[in] dt Analysis time step

--- a/include/particles/particle_fluid.h
+++ b/include/particles/particle_fluid.h
@@ -27,7 +27,7 @@ class FluidParticle : public mpm::Particle<Tdim> {
   FluidParticle(Index id, const VectorDim& coord);
 
   //! Destructor
-  ~FluidParticle() override{};
+  ~FluidParticle() override {};
 
   //! Delete copy constructor
   FluidParticle(const FluidParticle<Tdim>&) = delete;

--- a/include/particles/particle_twophase.h
+++ b/include/particles/particle_twophase.h
@@ -34,7 +34,7 @@ class TwoPhaseParticle : public mpm::Particle<Tdim> {
   TwoPhaseParticle(Index id, const VectorDim& coord, bool status);
 
   //! Destructor
-  ~TwoPhaseParticle() override{};
+  ~TwoPhaseParticle() override {};
 
   //! Delete copy constructor
   TwoPhaseParticle(const TwoPhaseParticle<Tdim>&) = delete;


### PR DESCRIPTION
**Describe the PR**
Clang-format has long been updated to newer versions; the one we used in the Docker was set at v10. Some of the old formatting styles have been deprecated, which causes many repetitive conflicts if one runs with more recent clang-format locally. 

This PR updates the default version considered in the continuous integrator (for testing purposes) to v18. It is not the newest version, but compatible with major Linux Ubuntu and macOS distributions used by the group.

**Related Issues/PRs**
N/A

**Additional context**
N/A
