### PR TITLE
[CMake] Remove deprecation warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
+cmake_minimum_required(VERSION 3.12)
+
 project(mpm LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
-
-cmake_minimum_required(VERSION 3.12)
 
 SET(CMAKE_COLOR_MAKEFILE ON)
 SET(CMAKE_VERBOSE_MAKEFILE OFF)
@@ -53,7 +53,10 @@ option(USE_PETSC "Use PETSC solver library" OFF)
 # CMake Modules
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
-# Boost Archive
+# Boost Archive — use Boost's own CMake config files (CMP0167 removes FindBoost)
+if(POLICY CMP0167)
+  cmake_policy(SET CMP0167 NEW)
+endif()
 find_package(Boost REQUIRED COMPONENTS filesystem)
 if(Boost_MAJOR_VERSION EQUAL 1 AND Boost_MINOR_VERSION LESS 69)
   find_package(Boost REQUIRED COMPONENTS filesystem system)

--- a/cmake/FindEigen3.cmake
+++ b/cmake/FindEigen3.cmake
@@ -30,7 +30,12 @@ if(NOT Eigen3_FIND_VERSION)
 endif(NOT Eigen3_FIND_VERSION)
 
 macro(_eigen3_check_version)
-  file(READ "${EIGEN3_INCLUDE_DIR}/Eigen/src/Core/util/Macros.h" _eigen3_version_header)
+  # Eigen 5.x moved version macros out of Macros.h into Eigen/Version
+  if(EXISTS "${EIGEN3_INCLUDE_DIR}/Eigen/Version")
+    file(READ "${EIGEN3_INCLUDE_DIR}/Eigen/Version" _eigen3_version_header)
+  else()
+    file(READ "${EIGEN3_INCLUDE_DIR}/Eigen/src/Core/util/Macros.h" _eigen3_version_header)
+  endif()
 
   string(REGEX MATCH "define[ \t]+EIGEN_WORLD_VERSION[ \t]+([0-9]+)" _eigen3_world_version_match "${_eigen3_version_header}")
   set(EIGEN3_WORLD_VERSION "${CMAKE_MATCH_1}")

--- a/external/spdlog/common.h
+++ b/external/spdlog/common.h
@@ -139,27 +139,15 @@ public:
     {
     }
     spdlog_ex(std::string msg, int last_errno)
-        : runtime_error(std::move(msg))
-        , last_errno_(last_errno)
-    {
-    }
-    const char *what() const SPDLOG_NOEXCEPT override
-    {
-        if (last_errno_)
-        {
+        : runtime_error([&msg, last_errno]() {
             fmt::memory_buffer buf;
-            std::string msg(runtime_error::what());
-            fmt::format_system_error(buf, last_errno_, msg);
-            return fmt::to_string(buf).c_str();
-        }
-        else
-        {
-            return runtime_error::what();
-        }
+            fmt::format_system_error(buf, last_errno, msg);
+            return fmt::to_string(buf);
+        }())
+    {
     }
 
 private:
-    int last_errno_{0};
 };
 
 //

--- a/external/spdlog/fmt/bundled/core.h
+++ b/external/spdlog/fmt/bundled/core.h
@@ -796,7 +796,11 @@ template<typename F, typename... Args>
 struct result_of<F(Args...)>
 {
     // A workaround for gcc 4.4 that doesn't allow F to be a reference.
+#if __cplusplus >= 201703L
+    typedef typename std::invoke_result<typename std::remove_reference<F>::type, Args...>::type type;
+#else
     typedef typename std::result_of<typename std::remove_reference<F>::type(Args...)>::type type;
+#endif
 };
 } // namespace internal
 


### PR DESCRIPTION
**Describe the PR**
This PR introduces some minor core changes to remove deprecation warnings due to the most recent minimum C++ updates to 2017. On top of that, certain adjustments are added to solve compilation errors when linking with the most recent Eigen version 5.

**Related Issues/PRs**
https://github.com/geomechanics/mpm/pull/119

**Additional context**
N/A
